### PR TITLE
add rewrite annotation to ingresses

### DIFF
--- a/clusters/kind-cluster/alice/sqnc-identity-service/values.yaml
+++ b/clusters/kind-cluster/alice/sqnc-identity-service/values.yaml
@@ -9,7 +9,9 @@ authType: NONE
 ingress:
   hostname: localhost
   paths:
-    - path: "/alice/sqnc-identity-service/(.*)"
+    - path: /alice/sqnc-identity-service/(.*)
       pathType: Prefix
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /$1
 node:
   enabled: false

--- a/clusters/kind-cluster/alice/sqnc-matchmaker-api/values.yaml
+++ b/clusters/kind-cluster/alice/sqnc-matchmaker-api/values.yaml
@@ -12,7 +12,9 @@ externalSqncIdentity:
 ingress:
   host: localhost
   paths:
-    - path: "/alice/sqnc-matchmaker-api/(.*)"
+    - path: /alice/sqnc-matchmaker-api/(.*)
       pathType: Prefix
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /$1
 node:
   enabled: false

--- a/clusters/kind-cluster/bob/sqnc-identity-service/values.yaml
+++ b/clusters/kind-cluster/bob/sqnc-identity-service/values.yaml
@@ -9,7 +9,9 @@ authType: NONE
 ingress:
   hostname: localhost
   paths:
-    - path: "/bob/sqnc-identity-service/(.*)"
+    - path: /bob/sqnc-identity-service/(.*)
       pathType: Prefix
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /$1
 node:
   enabled: false

--- a/clusters/kind-cluster/bob/sqnc-matchmaker-api/values.yaml
+++ b/clusters/kind-cluster/bob/sqnc-matchmaker-api/values.yaml
@@ -13,7 +13,9 @@ externalSqncIdentity:
 ingress:
   host: localhost
   paths:
-    - path: "/bob/sqnc-matchmaker-api/(.*)"
+    - path: /bob/sqnc-matchmaker-api/(.*)
       pathType: Prefix
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /$1
 node:
   enabled: false

--- a/clusters/kind-cluster/charlie/sqnc-identity-service/values.yaml
+++ b/clusters/kind-cluster/charlie/sqnc-identity-service/values.yaml
@@ -9,7 +9,9 @@ authType: NONE
 ingress:
   hostname: localhost
   paths:
-    - path: "/charlie/sqnc-identity-service/(.*)"
+    - path: /charlie/sqnc-identity-service/(.*)
       pathType: Prefix
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /$1
 node:
   enabled: false

--- a/clusters/kind-cluster/charlie/sqnc-matchmaker-api/values.yaml
+++ b/clusters/kind-cluster/charlie/sqnc-matchmaker-api/values.yaml
@@ -13,7 +13,9 @@ externalSqncIdentity:
 ingress:
   host: localhost
   paths:
-    - path: "/charlie/sqnc-matchmaker-api/(.*)"
+    - path: /charlie/sqnc-matchmaker-api/(.*)
       pathType: Prefix
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /$1
 node:
   enabled: false


### PR DESCRIPTION
Ingresses were broken because new version of nginx ingress controller requires the `nginx.ingress.kubernetes.io/rewrite-target` annotation to rewrite paths