### PR TITLE
L3-239: bugfix, removing certificates.yaml from each nginx controller.

### DIFF
--- a/clusters/l3-sqnc/capacity/nginx/kustomization.yaml
+++ b/clusters/l3-sqnc/capacity/nginx/kustomization.yaml
@@ -1,5 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - certificate.yaml
   - release.yaml

--- a/clusters/l3-sqnc/optimiser/nginx/kustomization.yaml
+++ b/clusters/l3-sqnc/optimiser/nginx/kustomization.yaml
@@ -1,5 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - certificate.yaml
   - release.yaml

--- a/clusters/l3-sqnc/order/nginx/kustomization.yaml
+++ b/clusters/l3-sqnc/order/nginx/kustomization.yaml
@@ -1,5 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - certificate.yaml
   - release.yaml


### PR DESCRIPTION
# What

A bug ticket, forgot to remove `certitificates.yaml` from `kustomization.yaml` files. 