### PR TITLE
Feature/openapi merger v1 1 0

### DIFF
--- a/clusters/kind-cluster/alice/open-api-merger/values.yaml
+++ b/clusters/kind-cluster/alice/open-api-merger/values.yaml
@@ -5,8 +5,8 @@ paths:
 baseUrl:
   - http://localhost:3080/alice/
 apiPublicUrlPrefix: /alice
-oauthClientId: "account-console"
-oauthAppName: "Account Console"
+oauthClientId: "alice-swagger"
+oauthAppName: "Alice Swagger"
 oauthUsePkce: true
 ingress:
   hostname: localhost

--- a/clusters/kind-cluster/alice/open-api-merger/values.yaml
+++ b/clusters/kind-cluster/alice/open-api-merger/values.yaml
@@ -5,6 +5,9 @@ paths:
 baseUrl:
   - http://localhost:3080/alice/
 apiPublicUrlPrefix: /alice
+oauthClientId: "account-console"
+oauthAppName: "Account Console"
+oauthUsePkce: true
 ingress:
   hostname: localhost
   paths:
@@ -14,3 +17,15 @@ ingress:
       pathType: Prefix
   annotations:
     nginx.ingress.kubernetes.io/rewrite-target: /$1
+securitySchema:
+  name: "oauth2"
+  type: "oauth2"
+  enabled: true
+  oauth2:
+    flows:
+      - authorizationCode
+      - clientCredentials
+    authorizationUrl: "/auth/realms/simple/protocol/openid-connect/auth"
+    tokenUrl: "/auth/realms/simple/protocol/openid-connect/token"
+    refreshUrl: "/auth/realms/simple/protocol/openid-connect/token"
+    scopes: {}

--- a/clusters/kind-cluster/alice/sqnc-identity-service/values.yaml
+++ b/clusters/kind-cluster/alice/sqnc-identity-service/values.yaml
@@ -1,5 +1,5 @@
 logLevel: info
-selfAddress: 12D3KooWEyoppNCUx8Yx66oV9fJnriXwCcXwDDUA2kj6vnc6iDEp
+selfAddress: 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
 externalSqncNode:
   host: alice-node-sqnc-node-0
   port: 9944

--- a/clusters/kind-cluster/base/flux-system/gotk-sync.yaml
+++ b/clusters/kind-cluster/base/flux-system/gotk-sync.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: feature/openapi-merger-v1-1-0
+    branch: main
   url: https://github.com/digicatapult/sqnc-flux-infra.git
 
 ---

--- a/clusters/kind-cluster/base/flux-system/gotk-sync.yaml
+++ b/clusters/kind-cluster/base/flux-system/gotk-sync.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: main
+    branch: feature/openapi-merger-v1-1-0
   url: https://github.com/digicatapult/sqnc-flux-infra.git
 
 ---

--- a/clusters/kind-cluster/bob/open-api-merger/values.yaml
+++ b/clusters/kind-cluster/bob/open-api-merger/values.yaml
@@ -5,6 +5,9 @@ paths:
 baseUrl:
   - http://localhost:3080/bob/
 apiPublicUrlPrefix: /bob
+oauthClientId: "bob-swagger"
+oauthAppName: "Bob Swagger"
+oauthUsePkce: true
 ingress:
   hostname: localhost
   paths:
@@ -14,3 +17,15 @@ ingress:
       pathType: Prefix
   annotations:
     nginx.ingress.kubernetes.io/rewrite-target: /$1
+securitySchema:
+  name: "oauth2"
+  type: "oauth2"
+  enabled: true
+  oauth2:
+    flows:
+      - authorizationCode
+      - clientCredentials
+    authorizationUrl: "/auth/realms/simple/protocol/openid-connect/auth"
+    tokenUrl: "/auth/realms/simple/protocol/openid-connect/token"
+    refreshUrl: "/auth/realms/simple/protocol/openid-connect/token"
+    scopes: {}

--- a/clusters/kind-cluster/bob/sqnc-identity-service/values.yaml
+++ b/clusters/kind-cluster/bob/sqnc-identity-service/values.yaml
@@ -1,5 +1,5 @@
 logLevel: info
-selfAddress: 12D3KooWHdiAxVd8uMQR1hGWXccidmfCwLqcMpGwR6QcTP6QRMuD
+selfAddress: 5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty
 externalSqncNode:
   host: bob-node-sqnc-node-0
   port: 9944

--- a/clusters/kind-cluster/charlie/open-api-merger/values.yaml
+++ b/clusters/kind-cluster/charlie/open-api-merger/values.yaml
@@ -5,6 +5,9 @@ paths:
 baseUrl:
   - http://localhost:3080/charlie/
 apiPublicUrlPrefix: /charlie
+oauthClientId: "charlie-swagger"
+oauthAppName: "Charlie Swagger"
+oauthUsePkce: true
 ingress:
   hostname: localhost
   paths:
@@ -14,3 +17,15 @@ ingress:
       pathType: Prefix
   annotations:
     nginx.ingress.kubernetes.io/rewrite-target: /$1
+securitySchema:
+  name: "oauth2"
+  type: "oauth2"
+  enabled: true
+  oauth2:
+    flows:
+      - authorizationCode
+      - clientCredentials
+    authorizationUrl: "/auth/realms/simple/protocol/openid-connect/auth"
+    tokenUrl: "/auth/realms/simple/protocol/openid-connect/token"
+    refreshUrl: "/auth/realms/simple/protocol/openid-connect/token"
+    scopes: {}

--- a/clusters/kind-cluster/charlie/sqnc-identity-service/values.yaml
+++ b/clusters/kind-cluster/charlie/sqnc-identity-service/values.yaml
@@ -1,5 +1,5 @@
 logLevel: info
-selfAddress: 12D3KooWSCufgHzV4fCwRijfH2k3abrpAJxTKxEvN1FDuRXA2U9x
+selfAddress: 5FLSigC9HGRKVhB9FiEo4Y3koPsNmBmLJbpXg2mp1hXcS59Y
 externalSqncNode:
   host: charlie-node-sqnc-node-0
   port: 9944

--- a/clusters/kind-cluster/keycloak/values.yaml
+++ b/clusters/kind-cluster/keycloak/values.yaml
@@ -8,23 +8,21 @@ keycloakConfigCli:
         "registrationAllowed": true,
         "clients": [
             {
-              "clientId": "account-console",
-              "name": "${client_account-console}",
-              "description": "",
-              "rootUrl": "${authBaseUrl}",
+              "clientId": "alice-swagger",
+              "name": "Alice Swagger",
+              "description": "Client for the Alice persona's swagger access ",
+              "rootUrl": "http://localhost:3080/alice/swagger",
               "adminUrl": "",
-              "baseUrl": "/realms/simple/account/",
+              "baseUrl": "/",
               "surrogateAuthRequired": false,
               "enabled": true,
               "alwaysDisplayInConsole": false,
               "clientAuthenticatorType": "client-secret",
               "redirectUris": [
-                "/realms/simple/account/*",
-                "https://www.keycloak.org/app/*"
+                "/*"
               ],
               "webOrigins": [
-                "http://localhost:3080",
-                "https://www.keycloak.org"
+                "+"
               ],
               "notBefore": 0,
               "bearerOnly": false,
@@ -32,30 +30,66 @@ keycloakConfigCli:
               "standardFlowEnabled": true,
               "implicitFlowEnabled": false,
               "directAccessGrantsEnabled": false,
-              "serviceAccountsEnabled": false,
-              "publicClient": true,
-              "frontchannelLogout": false,
+              "serviceAccountsEnabled": true,
+              "publicClient": false,
+              "frontchannelLogout": true,
               "protocol": "openid-connect",
               "attributes": {
                 "oidc.ciba.grant.enabled": "false",
                 "backchannel.logout.session.required": "true",
-                "post.logout.redirect.uris": "+",
-                "display.on.consent.screen": "false",
+                "post.logout.redirect.uris": "/*",
                 "oauth2.device.authorization.grant.enabled": "false",
-                "pkce.code.challenge.method": "S256",
-                "backchannel.logout.revoke.offline.tokens": "false"
+                "backchannel.logout.revoke.offline.tokens": "false",
+                "login_theme": "",
+                "display.on.consent.screen": false,
+                "frontchannel.logout.url": "",
+                "backchannel.logout.url": ""
               },
               "authenticationFlowBindingOverrides": {},
-              "fullScopeAllowed": false,
-              "nodeReRegistrationTimeout": 0,
+              "fullScopeAllowed": true,
+              "nodeReRegistrationTimeout": -1,
               "protocolMappers": [
                 {
-                  "id": "bf89b84b-60b8-46a4-91f4-159b7ca32d2e",
-                  "name": "audience resolve",
+                  "name": "Client Host",
                   "protocol": "openid-connect",
-                  "protocolMapper": "oidc-audience-resolve-mapper",
+                  "protocolMapper": "oidc-usersessionmodel-note-mapper",
                   "consentRequired": false,
-                  "config": {}
+                  "config": {
+                    "user.session.note": "clientHost",
+                    "introspection.token.claim": "true",
+                    "id.token.claim": "true",
+                    "access.token.claim": "true",
+                    "claim.name": "clientHost",
+                    "jsonType.label": "String"
+                  }
+                },
+                {
+                  "name": "Client ID",
+                  "protocol": "openid-connect",
+                  "protocolMapper": "oidc-usersessionmodel-note-mapper",
+                  "consentRequired": false,
+                  "config": {
+                    "user.session.note": "client_id",
+                    "introspection.token.claim": "true",
+                    "id.token.claim": "true",
+                    "access.token.claim": "true",
+                    "claim.name": "client_id",
+                    "jsonType.label": "String"
+                  }
+                },
+                {
+                  "name": "Client IP Address",
+                  "protocol": "openid-connect",
+                  "protocolMapper": "oidc-usersessionmodel-note-mapper",
+                  "consentRequired": false,
+                  "config": {
+                    "user.session.note": "clientAddress",
+                    "introspection.token.claim": "true",
+                    "id.token.claim": "true",
+                    "access.token.claim": "true",
+                    "claim.name": "clientAddress",
+                    "jsonType.label": "String"
+                  }
                 }
               ],
               "defaultClientScopes": [
@@ -70,7 +104,223 @@ keycloakConfigCli:
                 "phone",
                 "offline_access",
                 "microprofile-jwt"
-              ]
+              ],
+              "access": {
+                "view": true,
+                "configure": true,
+                "manage": true
+              },
+              "authorizationServicesEnabled": false
+            },
+            {
+              "clientId": "bob-swagger",
+              "name": "Bob Swagger",
+              "description": "Client for the Bob persona's swagger access ",
+              "rootUrl": "http://localhost:3080/bob/swagger",
+              "adminUrl": "",
+              "baseUrl": "/",
+              "surrogateAuthRequired": false,
+              "enabled": true,
+              "alwaysDisplayInConsole": false,
+              "clientAuthenticatorType": "client-secret",
+              "redirectUris": [
+                "/*"
+              ],
+              "webOrigins": [
+                "+"
+              ],
+              "notBefore": 0,
+              "bearerOnly": false,
+              "consentRequired": false,
+              "standardFlowEnabled": true,
+              "implicitFlowEnabled": false,
+              "directAccessGrantsEnabled": false,
+              "serviceAccountsEnabled": true,
+              "publicClient": false,
+              "frontchannelLogout": true,
+              "protocol": "openid-connect",
+              "attributes": {
+                "oidc.ciba.grant.enabled": "false",
+                "backchannel.logout.session.required": "true",
+                "post.logout.redirect.uris": "/*",
+                "oauth2.device.authorization.grant.enabled": "false",
+                "backchannel.logout.revoke.offline.tokens": "false",
+                "login_theme": "",
+                "display.on.consent.screen": false,
+                "frontchannel.logout.url": "",
+                "backchannel.logout.url": ""
+              },
+              "authenticationFlowBindingOverrides": {},
+              "fullScopeAllowed": true,
+              "nodeReRegistrationTimeout": -1,
+              "protocolMappers": [
+                {
+                  "name": "Client Host",
+                  "protocol": "openid-connect",
+                  "protocolMapper": "oidc-usersessionmodel-note-mapper",
+                  "consentRequired": false,
+                  "config": {
+                    "user.session.note": "clientHost",
+                    "introspection.token.claim": "true",
+                    "id.token.claim": "true",
+                    "access.token.claim": "true",
+                    "claim.name": "clientHost",
+                    "jsonType.label": "String"
+                  }
+                },
+                {
+                  "name": "Client ID",
+                  "protocol": "openid-connect",
+                  "protocolMapper": "oidc-usersessionmodel-note-mapper",
+                  "consentRequired": false,
+                  "config": {
+                    "user.session.note": "client_id",
+                    "introspection.token.claim": "true",
+                    "id.token.claim": "true",
+                    "access.token.claim": "true",
+                    "claim.name": "client_id",
+                    "jsonType.label": "String"
+                  }
+                },
+                {
+                  "name": "Client IP Address",
+                  "protocol": "openid-connect",
+                  "protocolMapper": "oidc-usersessionmodel-note-mapper",
+                  "consentRequired": false,
+                  "config": {
+                    "user.session.note": "clientAddress",
+                    "introspection.token.claim": "true",
+                    "id.token.claim": "true",
+                    "access.token.claim": "true",
+                    "claim.name": "clientAddress",
+                    "jsonType.label": "String"
+                  }
+                }
+              ],
+              "defaultClientScopes": [
+                "web-origins",
+                "acr",
+                "roles",
+                "profile",
+                "email"
+              ],
+              "optionalClientScopes": [
+                "address",
+                "phone",
+                "offline_access",
+                "microprofile-jwt"
+              ],
+              "access": {
+                "view": true,
+                "configure": true,
+                "manage": true
+              },
+              "authorizationServicesEnabled": false
+            },
+            {
+              "clientId": "charlie-swagger",
+              "name": "Charlie Swagger",
+              "description": "Client for the Charlie persona's swagger access ",
+              "rootUrl": "http://localhost:3080/charlie/swagger",
+              "adminUrl": "",
+              "baseUrl": "/",
+              "surrogateAuthRequired": false,
+              "enabled": true,
+              "alwaysDisplayInConsole": false,
+              "clientAuthenticatorType": "client-secret",
+              "redirectUris": [
+                "/*"
+              ],
+              "webOrigins": [
+                "+"
+              ],
+              "notBefore": 0,
+              "bearerOnly": false,
+              "consentRequired": false,
+              "standardFlowEnabled": true,
+              "implicitFlowEnabled": false,
+              "directAccessGrantsEnabled": false,
+              "serviceAccountsEnabled": true,
+              "publicClient": false,
+              "frontchannelLogout": true,
+              "protocol": "openid-connect",
+              "attributes": {
+                "oidc.ciba.grant.enabled": "false",
+                "backchannel.logout.session.required": "true",
+                "post.logout.redirect.uris": "/*",
+                "oauth2.device.authorization.grant.enabled": "false",
+                "backchannel.logout.revoke.offline.tokens": "false",
+                "login_theme": "",
+                "display.on.consent.screen": false,
+                "frontchannel.logout.url": "",
+                "backchannel.logout.url": ""
+              },
+              "authenticationFlowBindingOverrides": {},
+              "fullScopeAllowed": true,
+              "nodeReRegistrationTimeout": -1,
+              "protocolMappers": [
+                {
+                  "name": "Client Host",
+                  "protocol": "openid-connect",
+                  "protocolMapper": "oidc-usersessionmodel-note-mapper",
+                  "consentRequired": false,
+                  "config": {
+                    "user.session.note": "clientHost",
+                    "introspection.token.claim": "true",
+                    "id.token.claim": "true",
+                    "access.token.claim": "true",
+                    "claim.name": "clientHost",
+                    "jsonType.label": "String"
+                  }
+                },
+                {
+                  "name": "Client ID",
+                  "protocol": "openid-connect",
+                  "protocolMapper": "oidc-usersessionmodel-note-mapper",
+                  "consentRequired": false,
+                  "config": {
+                    "user.session.note": "client_id",
+                    "introspection.token.claim": "true",
+                    "id.token.claim": "true",
+                    "access.token.claim": "true",
+                    "claim.name": "client_id",
+                    "jsonType.label": "String"
+                  }
+                },
+                {
+                  "name": "Client IP Address",
+                  "protocol": "openid-connect",
+                  "protocolMapper": "oidc-usersessionmodel-note-mapper",
+                  "consentRequired": false,
+                  "config": {
+                    "user.session.note": "clientAddress",
+                    "introspection.token.claim": "true",
+                    "id.token.claim": "true",
+                    "access.token.claim": "true",
+                    "claim.name": "clientAddress",
+                    "jsonType.label": "String"
+                  }
+                }
+              ],
+              "defaultClientScopes": [
+                "web-origins",
+                "acr",
+                "roles",
+                "profile",
+                "email"
+              ],
+              "optionalClientScopes": [
+                "address",
+                "phone",
+                "offline_access",
+                "microprofile-jwt"
+              ],
+              "access": {
+                "view": true,
+                "configure": true,
+                "manage": true
+              },
+              "authorizationServicesEnabled": false
             }
           ]
       }


### PR DESCRIPTION
Updates to use the latest `openapi-merger`. Includes new clients for the 3 swagger apps deployed. Note this isn't perfect because of how helm values are merged. Need to look at that again, but that will be a small change. 