### PR TITLE
Incorrect location in the spec for chart version

### DIFF
--- a/clusters/l3-sqnc/capacity/identity-service/release.yaml
+++ b/clusters/l3-sqnc/capacity/identity-service/release.yaml
@@ -10,9 +10,9 @@ spec:
       retries: -1
   dependsOn:
     - name: magenta
-  version: 4.0.1
   chart:
     spec:
+      version: 4.0.1
       chart: sqnc-identity-service
       sourceRef:
         kind: HelmRepository

--- a/clusters/l3-sqnc/capacity/ipfs-node/release.yaml
+++ b/clusters/l3-sqnc/capacity/ipfs-node/release.yaml
@@ -10,9 +10,9 @@ spec:
       retries: -1
   dependsOn:
     - name: magenta
-  version: 4.0.1
   chart:
     spec:
+      version: 4.0.1
       chart: sqnc-ipfs
       sourceRef:
         kind: HelmRepository

--- a/clusters/l3-sqnc/capacity/magenta-node/release.yaml
+++ b/clusters/l3-sqnc/capacity/magenta-node/release.yaml
@@ -8,9 +8,9 @@ spec:
   install:
     remediation:
       retries: -1
-  version: 7.0.1
   chart:
     spec:
+      version: 7.0.1
       chart: sqnc-node
       sourceRef:
         kind: HelmRepository

--- a/clusters/l3-sqnc/capacity/matchmaker-api/release.yaml
+++ b/clusters/l3-sqnc/capacity/matchmaker-api/release.yaml
@@ -11,9 +11,9 @@ spec:
   dependsOn:
     - name: ipfs-capacity
     - name: capacity-identity-service
-  version: 2.0.1
   chart:
     spec:
+      version: 2.0.1
       chart: sqnc-matchmaker-api
       sourceRef:
         kind: HelmRepository

--- a/clusters/l3-sqnc/capacity/nginx/release.yaml
+++ b/clusters/l3-sqnc/capacity/nginx/release.yaml
@@ -9,9 +9,9 @@ spec:
     remediation:
       retries: -1
   releaseName: nginx-ingress-controller
-  version: 11.3.0
   chart:
     spec:
+      version: 11.3.0
       chart: nginx-ingress-controller
       sourceRef:
         kind: HelmRepository

--- a/clusters/l3-sqnc/capacity/open-api-merger/release.yaml
+++ b/clusters/l3-sqnc/capacity/open-api-merger/release.yaml
@@ -11,9 +11,9 @@ spec:
   dependsOn:
     - name: capacity-identity-service
     - name: capacity-matchmaker-api
-  version: 2.1.2
   chart:
     spec:
+      version: 2.1.2
       chart: openapi-merger
       sourceRef:
         kind: HelmRepository

--- a/clusters/l3-sqnc/capacity/red-node/release.yaml
+++ b/clusters/l3-sqnc/capacity/red-node/release.yaml
@@ -8,9 +8,9 @@ spec:
   install:
     remediation:
       retries: -1
-  version: 7.0.1
   chart:
     spec:
+      version: 7.0.1
       chart: sqnc-node
       sourceRef:
         kind: HelmRepository

--- a/clusters/l3-sqnc/cert-manager/release.yaml
+++ b/clusters/l3-sqnc/cert-manager/release.yaml
@@ -9,9 +9,9 @@ spec:
     remediation:
       retries: -1
   releaseName: cert-manager
-  version: 1.3.0
   chart:
     spec:
+      version: 1.3.0
       chart: cert-manager  
       sourceRef:
         kind: HelmRepository

--- a/clusters/l3-sqnc/keycloak/keycloak/release.yaml
+++ b/clusters/l3-sqnc/keycloak/keycloak/release.yaml
@@ -8,9 +8,9 @@ spec:
     remediation:
       retries: -1
   releaseName: keycloak
-  version: 21.3.1
   chart:
     spec:
+      version: 21.3.1
       chart: keycloak
       sourceRef:
         kind: HelmRepository

--- a/clusters/l3-sqnc/keycloak/nginx/release.yaml
+++ b/clusters/l3-sqnc/keycloak/nginx/release.yaml
@@ -9,9 +9,9 @@ spec:
     remediation:
       retries: -1
   releaseName: nginx-ingress-controller
-  version: 11.3.0
   chart:
     spec:
+      version: 11.3.0
       chart: nginx-ingress-controller
       sourceRef:
         kind: HelmRepository

--- a/clusters/l3-sqnc/optimiser/green-node/release.yaml
+++ b/clusters/l3-sqnc/optimiser/green-node/release.yaml
@@ -8,9 +8,9 @@ spec:
   install:
     remediation:
       retries: -1
-  version: 7.0.1
   chart:
     spec:
+      version: 7.0.1
       chart: sqnc-node
       sourceRef:
         kind: HelmRepository

--- a/clusters/l3-sqnc/optimiser/identity-service/release.yaml
+++ b/clusters/l3-sqnc/optimiser/identity-service/release.yaml
@@ -10,9 +10,9 @@ spec:
       retries: -1
   dependsOn:
     - name: yellow-node
-  version: 4.0.1
   chart:
     spec:
+      version: 4.0.1
       chart: sqnc-identity-service
       sourceRef:
         kind: HelmRepository

--- a/clusters/l3-sqnc/optimiser/ipfs-node/release.yaml
+++ b/clusters/l3-sqnc/optimiser/ipfs-node/release.yaml
@@ -10,9 +10,9 @@ spec:
       retries: -1
   dependsOn:
     - name: yellow-node
-  version: 4.0.1
   chart:
     spec:
+      version: 4.0.1
       chart: sqnc-ipfs
       sourceRef:
         kind: HelmRepository

--- a/clusters/l3-sqnc/optimiser/matchmaker-api/release.yaml
+++ b/clusters/l3-sqnc/optimiser/matchmaker-api/release.yaml
@@ -11,9 +11,9 @@ spec:
   dependsOn:
     - name: ipfs-optimiser
     - name: optimiser-identity-service
-  version: 2.0.1
   chart:
     spec:
+      version: 2.0.1
       chart: sqnc-matchmaker-api
       sourceRef:
         kind: HelmRepository

--- a/clusters/l3-sqnc/optimiser/nginx/release.yaml
+++ b/clusters/l3-sqnc/optimiser/nginx/release.yaml
@@ -9,9 +9,9 @@ spec:
     remediation:
       retries: -1
   releaseName: nginx-ingress-controller
-  version: 11.3.0
   chart:
     spec:
+      version: 11.3.0
       chart: nginx-ingress-controller
       sourceRef:
         kind: HelmRepository

--- a/clusters/l3-sqnc/optimiser/open-api-merger/release.yaml
+++ b/clusters/l3-sqnc/optimiser/open-api-merger/release.yaml
@@ -11,9 +11,9 @@ spec:
   dependsOn:
     - name: optimiser-identity-service
     - name: optimiser-matchmaker-api
-  version: 2.1.2
   chart:
     spec:
+      version: 2.1.2
       chart: openapi-merger
       sourceRef:
         kind: HelmRepository

--- a/clusters/l3-sqnc/optimiser/yellow-node/release.yaml
+++ b/clusters/l3-sqnc/optimiser/yellow-node/release.yaml
@@ -8,9 +8,9 @@ spec:
   install:
     remediation:
       retries: -1
-  version: 7.0.1
   chart:
     spec:
+      version: 7.0.1
       chart: sqnc-node
       sourceRef:
         kind: HelmRepository

--- a/clusters/l3-sqnc/order/cyan-node/release.yaml
+++ b/clusters/l3-sqnc/order/cyan-node/release.yaml
@@ -8,9 +8,9 @@ spec:
   install:
     remediation:
       retries: -1
-  version: 7.0.1
   chart:
     spec:
+      version: 7.0.1
       chart: sqnc-node
       sourceRef:
         kind: HelmRepository

--- a/clusters/l3-sqnc/order/identity-service/release.yaml
+++ b/clusters/l3-sqnc/order/identity-service/release.yaml
@@ -10,9 +10,9 @@ spec:
       retries: -1
   dependsOn:
     - name: blue-node
-  version: 4.0.1
   chart:
     spec:
+      version: 4.0.1
       chart: sqnc-identity-service
       sourceRef:
         kind: HelmRepository

--- a/clusters/l3-sqnc/order/ipfs-node/release.yaml
+++ b/clusters/l3-sqnc/order/ipfs-node/release.yaml
@@ -10,9 +10,9 @@ spec:
       retries: -1
   dependsOn:
     - name: blue-node
-  version: 4.0.1
   chart:
     spec:
+      version: 4.0.1
       chart: sqnc-ipfs
       sourceRef:
         kind: HelmRepository

--- a/clusters/l3-sqnc/order/matchmaker-api/release.yaml
+++ b/clusters/l3-sqnc/order/matchmaker-api/release.yaml
@@ -11,9 +11,9 @@ spec:
   dependsOn:
     - name: ipfs-order
     - name: order-identity-service
-  version: 2.0.1
   chart:
     spec:
+      version: 2.0.1
       chart: sqnc-matchmaker-api
       sourceRef:
         kind: HelmRepository

--- a/clusters/l3-sqnc/order/nginx/release.yaml
+++ b/clusters/l3-sqnc/order/nginx/release.yaml
@@ -9,9 +9,9 @@ spec:
     remediation:
       retries: -1
   releaseName: nginx-ingress-controller
-  version: 11.3.0
   chart:
     spec:
+      version: 11.3.0
       chart: nginx-ingress-controller
       sourceRef:
         kind: HelmRepository

--- a/clusters/l3-sqnc/order/open-api-merger/release.yaml
+++ b/clusters/l3-sqnc/order/open-api-merger/release.yaml
@@ -11,9 +11,9 @@ spec:
   dependsOn:
     - name: order-identity-service
     - name: order-matchmaker-api
-  version: 2.1.2
   chart:
     spec:
+      version: 2.1.2
       chart: openapi-merger
       sourceRef:
         kind: HelmRepository


### PR DESCRIPTION
# Pull Request

## Checklist
- [X] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings.
- [X] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [X] Bug Fix

## Linked tickets

N/A

## High level description

Incorrect location of the chart version

## Detailed description

In the helm release yaml files, the location of the version of the chart was incorrectly placed at the first `spec` level instead of inside the `spec.chart.spec.` level.


## Describe alternatives you've considered

N/A

## Operational impact

It will now work
## Additional context

N/A
