### PR TITLE
Removed unused node keys

### DIFF
--- a/clusters/l3-sqnc/order/blue-node/values.yaml
+++ b/clusters/l3-sqnc/order/blue-node/values.yaml
@@ -2,7 +2,6 @@ node:
   chain: l3-sqnc
   role: validator
   dataVolumeSize: 100Gi
-  customNodeKey: "0000000000000000000000000000000000000000000000000000000000000003"
   perNodeServices:
     setPublicAddressToExternal:
       enabled: false

--- a/clusters/l3-sqnc/order/cyan-node/values.yaml
+++ b/clusters/l3-sqnc/order/cyan-node/values.yaml
@@ -2,7 +2,6 @@ node:
   chain: l3-sqnc
   role: validator
   dataVolumeSize: 100Gi
-  customNodeKey: "0000000000000000000000000000000000000000000000000000000000000003"
   perNodeServices:
     setPublicAddressToExternal:
       enabled: false


### PR DESCRIPTION
# Pull Request

## Checklist
- [X] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [X] Bug Fix

## Linked tickets

N/A

## High level description

Removed node keys lines

## Detailed description

These node keys are being supplied by an in-cluster secret which overwrites whatever values are supplied in `values.yaml` so these lines are redundant.


## Describe alternatives you've considered

N/A

## Operational impact

There should be no operational impact as these are not the node-keys that were created in the genesis block, so they are clearly not being used.

## Additional context

N/A
