### PR TITLE
Typo

### DIFF
--- a/clusters/l3-sqnc/monitoring/kustomization.yaml
+++ b/clusters/l3-sqnc/monitoring/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 namespace: monitoring
 resources:
   - source.yaml
-  - monitoring-podmonitor-sync.yaml
+  - monitoring-pod-monitor-sync.yaml
   - kube-prometheus-stack
   - nginx
 configMapGenerator:


### PR DESCRIPTION
# Pull Request

## Checklist
- [X] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [X] Bug Fix

## Linked tickets

N/A

## High level description

Typo causes manifest to not be found

## Detailed description

There was a typo in the file that meant the manifest for the podMonitor sync could not be found


## Describe alternatives you've considered

N/A

## Operational impact

N/A

## Additional context

N/A
