### PR TITLE
Additiona Grafana dashboards

### DIFF
--- a/clusters/l3-sqnc/monitoring/kube-prometheus-stack/values.yaml
+++ b/clusters/l3-sqnc/monitoring/kube-prometheus-stack/values.yaml
@@ -86,7 +86,7 @@ grafana:
         options:
           path: /var/lib/grafana/dashboards
       - name: 'grafana-dashboards-kubernetes'
-        orgId: 2
+        orgId: 1
         folder: 'kubernetes'
         type: file
         disableDeletion: true

--- a/clusters/l3-sqnc/monitoring/kube-prometheus-stack/values.yaml
+++ b/clusters/l3-sqnc/monitoring/kube-prometheus-stack/values.yaml
@@ -85,7 +85,40 @@ grafana:
         editable: true
         options:
           path: /var/lib/grafana/dashboards
+      - name: 'grafana-dashboards-kubernetes'
+        orgId: 2
+        folder: 'kubernetes'
+        type: file
+        disableDeletion: true
+        editable: true
+        options:
+          path: /var/lib/grafana/dashboards/kubernetes
   dashboards:
+    grafana-dashboards-kubernetes:
+      k8s-system-api-server:
+        url: https://raw.githubusercontent.com/dotdc/grafana-dashboards-kubernetes/master/dashboards/k8s-system-api-server.json
+        token: ''
+        datasource: Prometheus
+      k8s-system-coredns:
+        url: https://raw.githubusercontent.com/dotdc/grafana-dashboards-kubernetes/master/dashboards/k8s-system-coredns.json
+        token: ''
+        datasource: Prometheus
+      k8s-views-global:
+        url: https://raw.githubusercontent.com/dotdc/grafana-dashboards-kubernetes/master/dashboards/k8s-views-global.json
+        token: ''
+        datasource: Prometheus
+      k8s-views-namespaces:
+        url: https://raw.githubusercontent.com/dotdc/grafana-dashboards-kubernetes/master/dashboards/k8s-views-namespaces.json
+        token: ''
+        datasource: Prometheus
+      k8s-views-nodes:
+        url: https://raw.githubusercontent.com/dotdc/grafana-dashboards-kubernetes/master/dashboards/k8s-views-nodes.json
+        token: ''
+        datasource: Prometheus
+      k8s-views-pods:
+        url: https://raw.githubusercontent.com/dotdc/grafana-dashboards-kubernetes/master/dashboards/k8s-views-pods.json
+        token: ''
+        datasource: Prometheus
     default:
       postgresql:
         gnetId: 9628
@@ -107,3 +140,22 @@ grafana:
         gnetId: 13840
         revision: 4
         datasource: Prometheus
+      velero:
+        gnetId: 16829
+        revision: 5
+        datasource: Prometheus
+      keycloak:
+        gnetId: 19659
+        revision: 1
+        datasource: Prometheus
+      node-exporter-full:
+        gnetId: 1860
+        revision: 37
+        datasource: Prometheus
+prometheus-node-exporter:
+  prometheus:
+    monitor:
+      relabelings:
+      - action: replace
+        sourceLabels: [__meta_kubernetes_pod_node_name]
+        targetLabel: nodename

--- a/clusters/l3-sqnc/monitoring/kube-prometheus-stack/values.yaml
+++ b/clusters/l3-sqnc/monitoring/kube-prometheus-stack/values.yaml
@@ -95,29 +95,33 @@ grafana:
           path: /var/lib/grafana/dashboards/kubernetes
   dashboards:
     grafana-dashboards-kubernetes:
+      k8s-addons-prometheus:
+        gnetId: 19105
+        revision: 3
+        datasource: Prometheus
       k8s-system-api-server:
-        url: https://raw.githubusercontent.com/dotdc/grafana-dashboards-kubernetes/master/dashboards/k8s-system-api-server.json
-        token: ''
+        gnetId: 15761
+        revision: 16
         datasource: Prometheus
       k8s-system-coredns:
-        url: https://raw.githubusercontent.com/dotdc/grafana-dashboards-kubernetes/master/dashboards/k8s-system-coredns.json
-        token: ''
+        gnetId: 15762
+        revision: 18
         datasource: Prometheus
       k8s-views-global:
-        url: https://raw.githubusercontent.com/dotdc/grafana-dashboards-kubernetes/master/dashboards/k8s-views-global.json
-        token: ''
+        gnetId: 15757
+        revision: 37
         datasource: Prometheus
       k8s-views-namespaces:
-        url: https://raw.githubusercontent.com/dotdc/grafana-dashboards-kubernetes/master/dashboards/k8s-views-namespaces.json
-        token: ''
+        gnetId: 15758
+        revision: 34
         datasource: Prometheus
       k8s-views-nodes:
-        url: https://raw.githubusercontent.com/dotdc/grafana-dashboards-kubernetes/master/dashboards/k8s-views-nodes.json
-        token: ''
+        gnetId: 15759
+        revision: 29
         datasource: Prometheus
       k8s-views-pods:
-        url: https://raw.githubusercontent.com/dotdc/grafana-dashboards-kubernetes/master/dashboards/k8s-views-pods.json
-        token: ''
+        gnetId: 15760
+        revision: 28
         datasource: Prometheus
     default:
       postgresql:


### PR DESCRIPTION
Added additional dashboards, including keycloak, velero and a set for Kubernetes itself.

# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [x] Feature

## Linked tickets

N/A

## High level description

Adds additional dashboards

## Detailed description

Adds dashboards for:
* Keycloak
* Velero
* node-exporter
* A group of kubernetes dashboards

Also relabels the node labels in prometheus


## Describe alternatives you've considered

N/A

## Operational impact

Potential impact is that the node re-label will prevent some dashboards from working.
## Additional context

N/A
