### PR TITLE
Grafana keycloak config

### DIFF
--- a/clusters/l3-sqnc/monitoring/kube-prometheus-stack/release.yaml
+++ b/clusters/l3-sqnc/monitoring/kube-prometheus-stack/release.yaml
@@ -37,4 +37,4 @@ spec:
   - kind: Secret
     name: grafana-client-secret
     valuesKey: grafana-client-secret
-    targetPath: grafana.grafana.ini.auth.generic_oauth.client_secret
+    targetPath: grafana.grafana\.ini.auth\.generic_oauth.client_secret

--- a/clusters/l3-sqnc/monitoring/kube-prometheus-stack/release.yaml
+++ b/clusters/l3-sqnc/monitoring/kube-prometheus-stack/release.yaml
@@ -34,3 +34,7 @@ spec:
     name: monitoring-secrets
     valuesKey: grafana_password
     targetPath: grafana.adminPassword
+  - kind: Secret
+    name: grafana-client-secret
+    valuesKey: grafana-client-secret
+    targetPath: grafana.grafana.ini.auth.generic_oauth.client_secret

--- a/clusters/l3-sqnc/monitoring/kube-prometheus-stack/values.yaml
+++ b/clusters/l3-sqnc/monitoring/kube-prometheus-stack/values.yaml
@@ -53,10 +53,21 @@ grafana:
     enabled: true
     namespace: monitoring
   ingress:
-    enabled: false
+    enabled: true
     ingressClassName: nginx-monitoring
     hosts:
       - grafana.dsch-l3.com
+  grafana.ini:
+    auth.generic_oauth:
+      enabled: true
+      name: Keycloak
+      allow_sign_up: true
+      scopes: profile,email,groups
+      auth_url: https://auth.dsch-l3.com/realms/monitoring/protocol/openid-connect/auth
+      token_url: https://auth.dsch-l3.com/realms/monitoring/protocol/openid-connect/token
+      api_url: https://auth.dsch-l3.com/realms/monitoring/protocol/openid-connect/userinfo
+      client_id: grafana
+      role_attribute_path: contains(groups[*], 'grafana_admins') && 'Admin' || contains(groups[*], 'grafana_users') && 'Viewer'
   persistence:
     enabled: true
     type: pvc

--- a/clusters/l3-sqnc/secrets/grafana-client-secrets.yaml
+++ b/clusters/l3-sqnc/secrets/grafana-client-secrets.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+data:
+    grafana-client-secret: ENC[AES256_GCM,data:8IGnTUNl0wQbTZSmMy9JRKNKRgJtKGKlg3MqEi3wuMaBAeTK5TI0yKwevfg=,iv:b16fiRfq/1HWYalBzQ57pPpJJoHZRbDfLsAcgBxjWKk=,tag:FtFACjP6DOaYrL2jRvknpQ==,type:str]
+kind: Secret
+metadata:
+    creationTimestamp: null
+    name: grafana-client-secret
+    namespace: monitoring
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2024-07-02T16:02:51Z"
+    mac: ENC[AES256_GCM,data:fgFdrNYBzTzcoFwI1V7yY93mHl115Fn2YZRnqDRoEdnfmQOjAgKQZHSMSe2cNeRfxtPRUJPkQGfrbEqUScEPdWfbAbaDv6NOWS0L1BiRhzehRBz/5CMr+6bxKaLs4UOxmPqG/H7qrayjCjyNDgS6IR5fBUYERI1UNS1szh9Jz2g=,iv:UOiLsL5+DiAQ6N2hG6q+mdztmGTPnqqbyJF7uGqKJKM=,tag:FYK9Yghmk9eTEuKQ2emeMQ==,type:str]
+    pgp:
+        - created_at: "2024-07-02T16:02:51Z"
+          enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            hF4DWK9rONmXZEsSAQdAJ5ht6s/DSjYHjqqHRd3+J13qD0SxCakaJyszFWra0lww
+            zpweCrbJsVWM9oWvDh+AnQppsd6G/FVVU63AxATBAtDF12E9ngXsavxmpT4BgX+2
+            1GYBCQIQnni0k/27TmB1S2ItaLUZeWRsjows6hmRw9br24FQsc0Jk73DKSQdeFU6
+            uroteH/JRDaBJQhmdbqN97kzD+/VXwseufR1uqdLNz/eq6kXtG/oudXedga7hv4C
+            lI3W38N15W0=
+            =vo3A
+            -----END PGP MESSAGE-----
+          fp: BC3A767578FF432C7414DE6A73A07B99E207F7AF
+    encrypted_regex: ^(data|stringData)$
+    version: 3.8.1


### PR DESCRIPTION
# Pull Request

## Checklist
- [X] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [X] Feature

## Linked tickets

SQNC-13

## High level description

Allow people to login to grafana via keycloak IDP.

## Detailed description

Added grafana configuration for using Keycloak as an IDP
moving grafana to be on the monitoring ingress resource
adds a grafana client secret


## Describe alternatives you've considered

N/A

## Operational impact

If we can no longer login to Keycloak we will need to revert this PR.

## Additional context

Users will need to be authorised via Okta and then need to be assigned a group role in the monitoring realm on Keycloak prior to being logged in.
