### PR TITLE
Fixing Blue nodes state

### DIFF
--- a/clusters/l3-sqnc/order/blue-node/values.yaml
+++ b/clusters/l3-sqnc/order/blue-node/values.yaml
@@ -16,7 +16,7 @@ node:
     - "--rpc-cors=all"
     - "--unsafe-rpc-external"
     - "--prometheus-external"
-    - "--state-pruning=100000"
+    - "--state-pruning=2500000"
     - "--bootnodes '/dns4/magenta-sqnc-node-0-rc-p2p.capacity.svc.cluster.local/tcp/30333/p2p/12D3KooWDvUB5uBh6msz4D1Te3vkfiod9FyMwPvHM56W46c1osKk'"
   serviceMonitor:
     enabled: true


### PR DESCRIPTION
# Pull Request

## Checklist
- [X] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [X] Bug Fix

## Linked tickets

SQNC-16

## High level description

The KV store for the blue node needs to be rebuilt so it can be queried

## Detailed description

The KV store needs to be queried by the order matchmaker API, however it is too far along so we need to rebuilt the state and resync from other nodes.


## Describe alternatives you've considered

N/A

## Operational impact

We will need to delete the blue nodes PVC to trigger a resync.

## Additional context

N/A
