### PR TITLE
Trying ParityDB for Order Blue

### DIFF
--- a/clusters/l3-sqnc/order/blue-node/values.yaml
+++ b/clusters/l3-sqnc/order/blue-node/values.yaml
@@ -17,6 +17,7 @@ node:
     - "--unsafe-rpc-external"
     - "--prometheus-external"
     - "--state-pruning=2500000"
+    - "--database=paritydb"
     - "--bootnodes '/dns4/magenta-sqnc-node-0-rc-p2p.capacity.svc.cluster.local/tcp/30333/p2p/12D3KooWDvUB5uBh6msz4D1Te3vkfiod9FyMwPvHM56W46c1osKk'"
   serviceMonitor:
     enabled: true


### PR DESCRIPTION
# Pull Request

## Checklist
- [X] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [X] Feature

## Linked tickets

SQNC-16

## High level description

Changing the DB to be ParityDB

## Detailed description

As the rocksDB syncs at a rate of 200bps we are testing ParityDB on this node to see if it is any faster


## Describe alternatives you've considered

RocksDB

## Operational impact

Need to nuke the PVC to resync

## Additional context

N/A
