### PR TITLE
Image that should process blocks at a limit of 100,000

### DIFF
--- a/clusters/l3-sqnc/order/matchmaker-api/values.yaml
+++ b/clusters/l3-sqnc/order/matchmaker-api/values.yaml
@@ -33,3 +33,5 @@ postgresql:
         - action: replace
           sourceLabels: [namespace]
           targetLabel: kubernetes_namespace
+image:
+  tag: "v3.0.80"


### PR DESCRIPTION
# Pull Request

## Checklist
- [X] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [X] Bug Fix

## Linked tickets

SQNC-17

## High level description

Order matchmaker API is OOM'ing due to having too many blocks to process

## Detailed description

Same as above but its because we are doing some interesting things with array reversals.


## Describe alternatives you've considered

Copying the Database

## Operational impact

Hopefully the matchmaker API for order will now work.

## Additional context

N/A
