### PR TITLE
Update genesis generation script 

### DIFF
--- a/docs/creating-a-new-cluster.md
+++ b/docs/creating-a-new-cluster.md
@@ -177,20 +177,20 @@ The described script allows for generating a new cluster with any number of desi
 
 ```
 ./scripts/make-new-cluster-genesis.sh \
-    -o alice:ns1
-    -o bob:ns2
-    -o charlie:ns3
-    -v red:ns1:alice \
-    -v green:ns2:bob \
-    -v blue:ns3:charlie \
-    -a bootnode:ns1:alice \
-    -a api-light:ns1:alice \
-    -a api-light:ns2:bob \
-    -a api-light:ns3:charlie \
+    -o alice:ns1 \
+    -o bob:ns2 \
+    -o charlie:ns3 \
+    -v red:ns1 \
+    -v green:ns2 \
+    -v blue:ns3 \
+    -a bootnode:ns1 \
+    -a api-light:ns1 \
+    -a api-light:ns2 \
+    -a api-light:ns3 \
     new-cluster > new-cluster.json
 ```
 
-would create a genesis for a new cluster called `new-cluster`. Three accounts `alice`, `bob` and `charlie` would be created in the namespaces `ns1`, `ns2` and `ns3` respectively. Three validator nodes called `red`, `green` and `blue` would be created in namespaces `ns1`, `ns2` and `ns3` and with owners `alice`, `bob` and `charlie` respectively. Two additional nodes (`bootnode` and `api-light`) would be created in `ns1` and owned by `alice`. Finally namespaces `ns2` and `ns3` would both contain an additional node called `api-light` owned by `bob` and `charlie` respectively.
+would create a genesis for a new cluster called `new-cluster`. Three accounts `alice`, `bob` and `charlie` would be created in the namespaces `ns1`, `ns2` and `ns3` respectively. Three validator nodes called `red`, `green` and `blue` would be created in namespaces `ns1`, `ns2` and `ns3` respectively along with matching owner accounts. Two additional nodes (`bootnode` and `api-light`) would be created in `ns1` along with owner accounts. Finally namespaces `ns2` and `ns3` would both contain an additional node called `api-light` with a corresponding owner account.
 
 Additional options may be specified to configure the docker image used to generate the genesis (defaults to `digicatapult/sqnc-node:latest`) and the kubernetes namespace secrets should be created in (defaults to `sqnc`). The script writes the final raw genesis file to stdout so can be safely redirected. This should then either be hosted publicly or built into the node to be deployed so that the chain can be referenced.
 


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [ ] Bug Fix
- [x] Chore
- [ ] Feature
- [ ] Documentation Update
- [ ] Code style update (formatting, local variables)
- [ ] Breaking Change (fix or feature that would cause existing functionality to change)

## Linked tickets

https://digicatapult.atlassian.net/browse/SQNC-95

## High level description

Updates the genesis script following the introduction of the the session and validatorSet pallets

## Detailed description

Following https://github.com/digicatapult/sqnc-node/pull/233 new chains should use an updated genesis format whereby validators are set in the `session` and `validatorSet` pallets. Note a few other changes here:

* updated logic so a new account is created as owner of each node. This is required by the `session` pallet
* updated documentation to actually match the script
* removed balance as an input as transactions aren't charged for. A nominal balance is still added to ensure account existance
* removed unused functions `assert_balance` and `create_node_identity`
* merged functions `assert_node_valid` and `assert_account_valid` as we need to make sure names don't overlap between the two and the functionality became equivalent

## Describe alternatives you've considered

None

## Operational impact

None

## Additional context

None
