### PR TITLE
Spreading pods around nodes

### DIFF
--- a/clusters/sqnc-staging/demanda/magenta-node/values.yaml
+++ b/clusters/sqnc-staging/demanda/magenta-node/values.yaml
@@ -23,3 +23,14 @@ node:
     enabled: true
     namespace: demanda
 storageClass: managed-csi-premium
+affinity:
+  podAntiAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+            - key: app.kubernetes.io/name
+              operator: In
+              values:
+                - sqnc-node
+        topologyKey: kubernetes.io/hostname
+

--- a/clusters/sqnc-staging/demanda/red-node/values.yaml
+++ b/clusters/sqnc-staging/demanda/red-node/values.yaml
@@ -24,3 +24,13 @@ node:
     enabled: true
     namespace: demanda
 storageClass: managed-csi-premium
+affinity:
+  podAntiAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+            - key: app.kubernetes.io/name
+              operator: In
+              values:
+                - sqnc-node
+        topologyKey: kubernetes.io/hostname


### PR DESCRIPTION
# Pull Request

## Checklist
- [X] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [X] Chore

## Linked tickets

SQNC-43

## High level description

Sets an `antiAffinity` to spread `sqnc-node` pods around the cluster so we have them on each `node`

## Detailed description

Sets an `antiAffinity` to spread `sqnc-node` pods around the cluster so we have them on each `node` this is so when we perform rolling upgrades of `nodes` there should always be sufficient amount of nodes in the cluster to maintain a quorum and not brick a blockchain.


## Describe alternatives you've considered

<!-- A clear and concise description of the alternative solutions you've considered. Be sure to explain why the existing customisability isn't suitable for this feature. -->

## Operational impact

<!--- A description of any operational considerations associated with the change. Is there anything in particular we should be looking at when deploying the change to make sure it is working as intended. If something goes wrong will any special actions be needed to revert the change. -->

## Additional context

<!-- Add any other context or screenshots about the feature request here. -->
