### PR TITLE
Added sqnc-node services for prod

### DIFF
--- a/clusters/l3-sqnc/capacity/identity-service/values.yaml
+++ b/clusters/l3-sqnc/capacity/identity-service/values.yaml
@@ -1,7 +1,7 @@
 logLevel: info
 selfAddress: 5Gh5cFC3sPS7pK8SN41Ytp6VFsMyPpvKxtrrcLpkf19u9W83
 externalSqncNode:
-  host: magenta-sqnc-node-0
+  host: sqnc-node
   port: 9944
 auth:
   clientId: 'l3'

--- a/clusters/l3-sqnc/capacity/ipfs-node/values.yaml
+++ b/clusters/l3-sqnc/capacity/ipfs-node/values.yaml
@@ -1,5 +1,5 @@
 externalSqncNode:
-  host: magenta-sqnc-node-0
+  host: sqnc-node
   port: 9944
 persistence:
   storageClass: managed-csi-premium

--- a/clusters/l3-sqnc/capacity/kustomization.yaml
+++ b/clusters/l3-sqnc/capacity/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
   - nginx
   - open-api-merger
   - source.yaml
+  - service-sqnc-node.yaml
 configMapGenerator:
   - name: capacity-values
     files:

--- a/clusters/l3-sqnc/capacity/matchmaker-api/values.yaml
+++ b/clusters/l3-sqnc/capacity/matchmaker-api/values.yaml
@@ -1,6 +1,6 @@
 logLevel: debug
 externalSqncNode:
-  host: magenta-sqnc-node-0
+  host: sqnc-node
   port: 9944
 externalSqncIpfs:
   host: ipfs-capacity-sqnc-ipfs-api

--- a/clusters/l3-sqnc/capacity/service-sqnc-node.yaml
+++ b/clusters/l3-sqnc/capacity/service-sqnc-node.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: sqnc-node
+  namespace: demanda
+spec:
+  type: ClusterIP
+  sessionAffinity: ClientIP
+  sessionAffinityConfig:
+    clientIP:
+      timeoutSeconds: 10
+  ports:
+    - name: rpc
+      port: 9944
+      protocol: TCP  
+      targetPort: 9944
+  selector:
+    app.kubernetes.io/name: sqnc-node

--- a/clusters/l3-sqnc/capacity/service-sqnc-node.yaml
+++ b/clusters/l3-sqnc/capacity/service-sqnc-node.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: sqnc-node
-  namespace: demanda
+  namespace: capacity
 spec:
   type: ClusterIP
   sessionAffinity: ClientIP

--- a/clusters/l3-sqnc/optimiser/identity-service/values.yaml
+++ b/clusters/l3-sqnc/optimiser/identity-service/values.yaml
@@ -1,7 +1,7 @@
 logLevel: info
 selfAddress: 5HdXyANz5ySq8FPBxhdbm2d8FjPRKZHEAnNtypaAWix8BDRJ
 externalSqncNode:
-  host: yellow-node-sqnc-node-0
+  host: sqnc-node
   port: 9944
 auth:
   clientId: 'l3'

--- a/clusters/l3-sqnc/optimiser/ipfs-node/values.yaml
+++ b/clusters/l3-sqnc/optimiser/ipfs-node/values.yaml
@@ -1,5 +1,5 @@
 externalSqncNode:
-  host: yellow-node-sqnc-node-0
+  host: sqnc-node
   port: 9944
 ipfs:
   bootNodeAddress: /dns4/ipfs-capacity-sqnc-ipfs-0-swarm.capacity.svc.cluster.local/tcp/4001/p2p/12D3KooWLMN2Afe5e6WcoAQKDsmhzPxj1YuDGKhn9T4vgVmwu9Vz

--- a/clusters/l3-sqnc/optimiser/kustomization.yaml
+++ b/clusters/l3-sqnc/optimiser/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
   - nginx
   - open-api-merger
   - source.yaml
+  - service-sqnc-node.yaml
 configMapGenerator:
   - name: optimiser-values
     files:

--- a/clusters/l3-sqnc/optimiser/matchmaker-api/values.yaml
+++ b/clusters/l3-sqnc/optimiser/matchmaker-api/values.yaml
@@ -1,6 +1,6 @@
 logLevel: debug
 externalSqncNode:
-  host: yellow-node-sqnc-node-0
+  host: sqnc-node
   port: 9944
 externalSqncIpfs:
   host: ipfs-optimiser-sqnc-ipfs-api

--- a/clusters/l3-sqnc/optimiser/service-sqnc-node.yaml
+++ b/clusters/l3-sqnc/optimiser/service-sqnc-node.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: sqnc-node
+  namespace: optimiser
+spec:
+  type: ClusterIP
+  sessionAffinity: ClientIP
+  sessionAffinityConfig:
+    clientIP:
+      timeoutSeconds: 10
+  ports:
+    - name: rpc
+      port: 9944
+      protocol: TCP  
+      targetPort: 9944
+  selector:
+    app.kubernetes.io/name: sqnc-node

--- a/clusters/l3-sqnc/order/identity-service/values.yaml
+++ b/clusters/l3-sqnc/order/identity-service/values.yaml
@@ -1,7 +1,7 @@
 logLevel: info
 selfAddress: 5Df4d56pDyPz3RM3RBLYC7nyhhL9mGXchrV1dkyYPt5u8H88
 externalSqncNode:
-  host: blue-node-sqnc-node-0
+  host: sqnc-node
   port: 9944
 auth:
   clientId: 'l3'

--- a/clusters/l3-sqnc/order/ipfs-node/values.yaml
+++ b/clusters/l3-sqnc/order/ipfs-node/values.yaml
@@ -1,5 +1,5 @@
 externalSqncNode:
-  host: blue-node-sqnc-node-0
+  host: sqnc-node
   port: 9944
 ipfs:
   bootNodeAddress: /dns4/ipfs-capacity-sqnc-ipfs-0-swarm.capacity.svc.cluster.local/tcp/4001/p2p/12D3KooWLMN2Afe5e6WcoAQKDsmhzPxj1YuDGKhn9T4vgVmwu9Vz

--- a/clusters/l3-sqnc/order/kustomization.yaml
+++ b/clusters/l3-sqnc/order/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
   - nginx
   - open-api-merger
   - source.yaml
+  - service-sqnc-node.yaml
 configMapGenerator:
   - name: order-values
     files:

--- a/clusters/l3-sqnc/order/matchmaker-api/values.yaml
+++ b/clusters/l3-sqnc/order/matchmaker-api/values.yaml
@@ -1,6 +1,6 @@
 logLevel: trace
 externalSqncNode:
-  host: blue-node-sqnc-node-0
+  host: sqnc-node
   port: 9944
 externalSqncIpfs:
   host: ipfs-order-sqnc-ipfs-api

--- a/clusters/l3-sqnc/order/service-sqnc-node.yaml
+++ b/clusters/l3-sqnc/order/service-sqnc-node.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: sqnc-node
+  namespace: order
+spec:
+  type: ClusterIP
+  sessionAffinity: ClientIP
+  sessionAffinityConfig:
+    clientIP:
+      timeoutSeconds: 10
+  ports:
+    - name: rpc
+      port: 9944
+      protocol: TCP  
+      targetPort: 9944
+  selector:
+    app.kubernetes.io/name: sqnc-node


### PR DESCRIPTION
# Pull Request

## Checklist
- [X] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [X] Feature

## Linked tickets

SQNC-119

## High level description

Adds sqnc-node services to loadbalance between both nodes for dependent services

## Detailed description

Points all dependent services at a sqnc-node svc for each persona.


## Describe alternatives you've considered

<!-- A clear and concise description of the alternative solutions you've considered. Be sure to explain why the existing customisability isn't suitable for this feature. -->

## Operational impact

<!--- A description of any operational considerations associated with the change. Is there anything in particular we should be looking at when deploying the change to make sure it is working as intended. If something goes wrong will any special actions be needed to revert the change. -->

## Additional context

<!-- Add any other context or screenshots about the feature request here. -->
