### PR TITLE
Cyan Node state pruning and parityDB

### DIFF
--- a/clusters/l3-sqnc/order/cyan-node/values.yaml
+++ b/clusters/l3-sqnc/order/cyan-node/values.yaml
@@ -16,6 +16,8 @@ node:
     - "--rpc-cors=all"
     - "--unsafe-rpc-external"
     - "--prometheus-external"
+    - "--state-pruning=5000000"
+    - "--database=paritydb"
     - "--bootnodes '/dns4/magenta-sqnc-node-0-rc-p2p.capacity.svc.cluster.local/tcp/30333/p2p/12D3KooWDvUB5uBh6msz4D1Te3vkfiod9FyMwPvHM56W46c1osKk'"
   serviceMonitor:
     enabled: true


### PR DESCRIPTION
# Pull Request

## Checklist
- [X] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [ ] Chore

## Linked tickets

SQNC-118

## High level description

Switches Cyan node to using ParityDB and sets state pruning to 5 million blocks

## Detailed description

<!-- A detailed description of the feature and if possible describe how has been implemented. -->


## Describe alternatives you've considered

<!-- A clear and concise description of the alternative solutions you've considered. Be sure to explain why the existing customisability isn't suitable for this feature. -->

## Operational impact

<!--- A description of any operational considerations associated with the change. Is there anything in particular we should be looking at when deploying the change to make sure it is working as intended. If something goes wrong will any special actions be needed to revert the change. -->

## Additional context

<!-- Add any other context or screenshots about the feature request here. -->
