### PR TITLE
Add Kind validation workflow

### DIFF
--- a/.github/workflows/validate-kind.yaml
+++ b/.github/workflows/validate-kind.yaml
@@ -129,10 +129,10 @@ jobs:
         if: failure()
         run: |
           namespaces=$(kubectl get namespaces -A | tail -n +2 | awk '{print $1}')
-          for $ns in $(echo $namespaces); do
+          for ns in $(echo $namespaces); do
             pods=$(kubectl get pods -o jsonpath='{range .items[?(@.status.containerStatuses[-1:].state.waiting)]}{.metadata.name}: {@.status.containerStatuses[*].state.waiting.reason}{"\n"}{end}' -n $ns | tail -n +2 | awk '{print $1}')
             if [ ! -z $pods ]; then
-              for $pod in $(echo $pods); do
+              for pod in $(echo $pods); do
                 kubectl describe pod $pod -n $ns
                 kubectl logs $pod -n $ns
               done

--- a/.github/workflows/validate-kind.yaml
+++ b/.github/workflows/validate-kind.yaml
@@ -32,7 +32,7 @@ jobs:
           --url=${{ github.event.repository.html_url }} \
           --branch=${GITHUB_REF#refs/heads/} \
           --username=${GITHUB_ACTOR} \
-          --password=${{ secrets.GITHUB_TOKEN }} \
+          --password=${{ secrets.GITHUB_TOKEN }}
           flux create kustomization flux-system \
           --source=flux-system \
           --path=./clusters/kind-cluster/base

--- a/.github/workflows/validate-kind.yaml
+++ b/.github/workflows/validate-kind.yaml
@@ -28,6 +28,7 @@ jobs:
         uses: helm/kind-action@v1.12.0
         with:
           cluster_name: sqnc-flux-infra
+          config: ./scripts/kind-cluster-config.yaml
       - name: Install Flux to cluster
         run: flux install
       - name: Source repository and reconcile

--- a/.github/workflows/validate-kind.yaml
+++ b/.github/workflows/validate-kind.yaml
@@ -19,7 +19,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@main
       - name: Install Flux
-        run: brew install fluxcd/tap/flux@2.3
+        run: |
+          /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+          brew install fluxcd/tap/flux@2.3
+          flux -v
       - name: Init Kind action
         uses: helm/kind-action@v1.12.0
         with:

--- a/.github/workflows/validate-kind.yaml
+++ b/.github/workflows/validate-kind.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@main
       - name: Init Flux action
-        uses: fluxcd/flux2/action@main
+        uses: fluxcd/flux2/action@2.3
       - name: Init Kind action
         uses: helm/kind-action@v1.12.0
         with:

--- a/.github/workflows/validate-kind.yaml
+++ b/.github/workflows/validate-kind.yaml
@@ -35,23 +35,12 @@ jobs:
         run: |
           git config user.name ${GITHUB_ACTOR}
           git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
-      - name: Patch GitOps branch to match PR
-        if: |
-          github.event_name == 'pull_request' &&
-          contains('refs/heads/renovate', github.ref)
-        run: |
-          patch=${GITHUB_REF#refs/heads/}
-          sed -i -r "s#(branch:).*#\1 $patch#" \
-            ./clusters/kind-cluster/base/flux-system/gotk-sync.yaml
-          git add ./clusters/kind-cluster/base/flux-system/gotk-sync.yaml
-          git commit -am "Patch GitOps branch to match PR"
-          git push -u origin $patch
-      - name: Source repository and reconcile
+      - name: Create source and kustomization on main
         if: success()
         run: |
           flux create source git flux-system \
           --url=${{ github.event.repository.html_url }} \
-          --branch=${GITHUB_REF#refs/heads/} \
+          --branch=main \
           --username=${GITHUB_ACTOR} \
           --password=${{ secrets.GITHUB_TOKEN }}
           flux create kustomization flux-system \
@@ -76,6 +65,33 @@ jobs:
           kubectl -n alice wait helmrelease --all --for=condition=ready --timeout=10m
           kubectl -n bob wait helmrelease --all --for=condition=ready --timeout=10m
           kubectl -n charlie wait helmrelease --all --for=condition=ready --timeout=10m
+      - name: Patch GitOps branch to match PR
+        if: |
+          success() &&
+          github.event_name == 'pull_request' &&
+          contains('refs/heads/renovate', github.ref)
+        run: |
+          patch=${GITHUB_REF#refs/heads/}
+          sed -i -r "s#(branch:).*#\1 $patch#" \
+            ./clusters/kind-cluster/base/flux-system/gotk-sync.yaml
+          git add ./clusters/kind-cluster/base/flux-system/gotk-sync.yaml
+          git commit -am "Patch GitOps branch to match PR"
+          git push -u origin $patch
+      - name: Reconcile the update
+        if: |
+          success() &&
+          github.event_name == 'pull_request' &&
+          contains('refs/heads/renovate', github.ref)
+        run: |
+          flux suspend kustomization --all
+          flux create source git flux-system \
+          --url=${{ github.event.repository.html_url }} \
+          --branch=${GITHUB_REF#refs/heads/} \
+          --username=${GITHUB_ACTOR} \
+          --password=${{ secrets.GITHUB_TOKEN }}
+          flux resume kustomization --all
+          kubectl wait kustomization --all --all-namespaces --for=condition=ready --timeout=10m
+          kubectl wait helmrelease --all --all-namespaces --for=condition=ready --timeout=10m
       - name: Comment with test results
         if: |
           success() &&
@@ -83,11 +99,19 @@ jobs:
           contains('refs/heads/renovate', github.ref)
         run: |
           node="alice"
-          echo "test results for $node/sqnc-node-test-suite:\n" >> comment.txt
-          kubectl logs -n $node job/$node-node-sqnc-node-0-post-install-test-suite >> comment.txt
-          echo "test results for $node/sqnc-matchmaker-api-test-suite:\n" >> comment.txt
-          kubectl logs -n $node job/$node-sqnc-matchmaker-api-test-suite >> comment.txt
-          gh pr comment ${{ github.event.number }} --body-file comment.txt
+          if [ $(flux logs -n $node | grep -Eo "$node-node.$node.+'upgrade'" | tail -n 1) ]; then
+            echo "upgrade test results for $node/sqnc-node-test-suite:\n" >> comment.txt
+            kubectl logs -n $node job/$node-node-sqnc-node-0-post-install-test-suite >> comment.txt || \
+            echo "error querying $node-node-sqnc-node-0-post-install-test-suite" >> comment.txt
+          fi
+          if [ $(flux logs -n $node | grep -Eo "$node-sqnc-matchmaker-api.+'upgrade'" | tail -n 1) ]; then
+            echo "upgrade test results for $node/sqnc-matchmaker-api-test-suite:\n" >> comment.txt
+            kubectl logs -n $node job/$node-sqnc-matchmaker-api-test-suite >> comment.txt || \
+            echo "error querying $node-sqnc-matchmaker-api-test-suite" >> comment.txt
+          fi
+          if [ -f comment.txt ]; then
+            gh pr comment ${{ github.event.number }} --body-file comment.txt
+          fi
         env:
           GH_TOKEN: ${{ github.token }}
       - name: Return GitOps branch to main
@@ -101,6 +125,12 @@ jobs:
           git add ./clusters/kind-cluster/base/flux-system/gotk-sync.yaml
           git commit -am "Return GitOps branch to main"
           git push -u origin ${GITHUB_REF#refs/heads/}
+      - name: Debug Flux logs
+        if: failure()
+        run: flux logs --level=debug --all-namespaces
+      - name: Return Flux log errors
+        if: failure()
+        run: flux logs --level=error --all-namespaces
       - name: Debug Flux controller state
         if: failure()
         run: kubectl -n flux-system get all
@@ -116,6 +146,3 @@ jobs:
       - name: Report all resources
         if: failure()
         run: flux get all --all-namespaces
-      - name: Report all services
-        if: failure()
-        run: kubectl get svc -n kube-system

--- a/.github/workflows/validate-kind.yaml
+++ b/.github/workflows/validate-kind.yaml
@@ -125,6 +125,19 @@ jobs:
           git add ./clusters/kind-cluster/base/flux-system/gotk-sync.yaml
           git commit -am "Return GitOps branch to main"
           git push -u origin ${GITHUB_REF#refs/heads/}
+      - name: Describe failing pods
+        if: failure()
+        run: |
+          namespaces=$(kubectl get namespaces -A | tail -n +2 | awk '{print $1}')
+          for $ns in $(echo $namespaces); do
+            pods=$(kubectl get pods -o jsonpath='{range .items[?(@.status.containerStatuses[-1:].state.waiting)]}{.metadata.name}: {@.status.containerStatuses[*].state.waiting.reason}{"\n"}{end}' -n $ns | tail -n +2 | awk '{print $1}')
+            if [ ! -z $pods ]; then
+              for $pod in $(echo $pods); do
+                kubectl describe pod $pod -n $ns
+                kubectl logs $pod -n $ns
+              done
+            fi
+          done
       - name: Debug Flux logs
         if: failure()
         run: flux logs --level=debug --all-namespaces

--- a/.github/workflows/validate-kind.yaml
+++ b/.github/workflows/validate-kind.yaml
@@ -89,3 +89,6 @@ jobs:
         if: failure()
         run: |
           flux get all --all-namespaces
+      - name: get all svc
+        if: failure()
+        run: kubectl get svc -n kube-system

--- a/.github/workflows/validate-kind.yaml
+++ b/.github/workflows/validate-kind.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@main
       - name: Init Flux action
-        uses: fluxcd/flux2/action@2.3
+        uses: fluxcd/flux2/action@896e0fa46d5107a05e953dd0a5261d78a145ec8c
       - name: Init Kind action
         uses: helm/kind-action@v1.12.0
         with:

--- a/.github/workflows/validate-kind.yaml
+++ b/.github/workflows/validate-kind.yaml
@@ -55,6 +55,16 @@ jobs:
           kubectl -n alice wait helmrelease --all --for=condition=ready --timeout=10m
           kubectl -n bob wait helmrelease --all --for=condition=ready --timeout=10m
           kubectl -n charlie wait helmrelease --all --for=condition=ready --timeout=10m
+      # - name: Comment with test results
+      #   run: |
+      #     node="alice"
+      #     echo "test results for $node/sqnc-node-test-suite:\n" >> comment.txt
+      #     kubectl logs -n $node job/$node-node-sqnc-node-0-post-install-test-suite >> comment.txt
+      #     echo "test results for $node/sqnc-matchmaker-api-test-suite:\n" >> comment.txt
+      #     kubectl logs -n $node job/$node-sqnc-matchmaker-api-test-suite >> comment.txt
+      #     gh pr comment ${{ github.event.number }} --body-file comment.txt
+      #   env:
+      #     GH_TOKEN: ${{ github.token }}
       - name: Debug Flux controller state
         if: failure()
         run: |

--- a/.github/workflows/validate-kind.yaml
+++ b/.github/workflows/validate-kind.yaml
@@ -1,0 +1,77 @@
+name: validate-kind-e2e
+
+on:
+  workflow_dispatch:
+  # pull_request:
+  #   types:
+  #     - opened
+  #     - reopened
+  #   branches:
+  #     - 'renovate/**'
+  push:
+    branches:
+      - feature/add_e2e_kind_action
+
+jobs:
+  kubernetes:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@main
+      - name: Init Flux action
+        uses: fluxcd/flux2/action@main
+      - name: Init Kind action
+        uses: helm/kind-action@v1.12.0
+        with:
+          cluster_name: sqnc-flux-infra
+      - name: Install Flux to cluster
+        run: flux install
+      - name: Source repository and reconcile
+        run: |
+          flux create source git flux-system \
+          --url=${{ github.event.repository.html_url }} \
+          --branch=${GITHUB_REF#refs/heads/} \
+          --username=${GITHUB_ACTOR} \
+          --password=${{ secrets.GITHUB_TOKEN }} \
+          flux create kustomization flux-system \
+          --source=flux-system \
+          --path=./clusters/kind-cluster/base
+      - name: Verify Flux kustomizations
+        run: |
+          kubectl -n kube-system wait kustomization/nginx-sync --for=condition=ready --timeout=10m
+          kubectl -n keycloak wait kustomization/keycloak-sync --for=condition=ready --timeout=10m
+          kubectl -n monitoring wait kustomization/monitoring-sync --for=condition=ready --timeout=10m
+          kubectl -n loki wait kustomization/promtail-sync --for=condition=ready --timeout=10m
+          kubectl -n loki wait kustomization/loki-sync --for=condition=ready --timeout=10m
+          kubectl -n alice wait kustomization/alice-sync --for=condition=ready --timeout=10m
+          kubectl -n bob wait kustomization/bob-sync --for=condition=ready --timeout=10m
+          kubectl -n charlie wait kustomization/charlie-sync --for=condition=ready --timeout=10m
+      - name: Verify Helm releases
+        run: |
+          kubectl -n kube-system wait helmrelease --all --for=condition=ready --timeout=10m
+          kubectl -n keycloak wait helmrelease --all --for=condition=ready --timeout=10m
+          kubectl -n monitoring wait helmrelease --all --for=condition=ready --timeout=10m
+          kubectl -n loki wait helmrelease --all --for=condition=ready --timeout=10m
+          kubectl -n alice wait helmrelease --all --for=condition=ready --timeout=10m
+          kubectl -n bob wait helmrelease --all --for=condition=ready --timeout=10m
+          kubectl -n charlie wait helmrelease --all --for=condition=ready --timeout=10m
+      - name: Debug Flux controller state
+        if: failure()
+        run: |
+          kubectl -n flux-system get all
+      - name: Debug source-controller logs
+        if: failure()
+        run: |
+          kubectl -n flux-system logs deploy/source-controller
+      - name: Debug kustomize-controller logs
+        if: failure()
+        run: |
+          kubectl -n flux-system logs deploy/kustomize-controller
+      - name: Debug helm-controller logs
+        if: failure()
+        run: |
+          kubectl -n flux-system logs deploy/helm-controller
+      - name: Report all resources
+        if: failure()
+        run: |
+          flux get all --all-namespaces

--- a/.github/workflows/validate-kind.yaml
+++ b/.github/workflows/validate-kind.yaml
@@ -18,9 +18,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@main
+      - name: Init Homebrew
+        uses: Homebrew/actions/setup-homebrew@master
       - name: Install Flux
         run: |
-          /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
           brew install fluxcd/tap/flux@2.3
           flux -v
       - name: Init Kind action

--- a/.github/workflows/validate-kind.yaml
+++ b/.github/workflows/validate-kind.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@main
       - name: Init Flux action
-        uses: fluxcd/flux2/action@896e0fa46d5107a05e953dd0a5261d78a145ec8c
+        uses: fluxcd/flux2/action@v2.3.0
       - name: Init Kind action
         uses: helm/kind-action@v1.12.0
         with:

--- a/.github/workflows/validate-kind.yaml
+++ b/.github/workflows/validate-kind.yaml
@@ -100,11 +100,8 @@ jobs:
                 kubectl logs job/$job -n $ns
                 pods=$(kubectl get pods --selector=job-name=$job -n $ns | tail -n +2 | awk '{print $1}')
                 for pod in $(echo $pods); do
-                  phase=$(kubectl get pods $pod -n $ns --no-headers -o custom-columns=":status.phase")
-                  if [ "$phase" = "Failed" ]; then
-                    kubectl describe pod $pod -n $ns
-                    kubectl logs $pod -n $ns
-                  fi
+                  kubectl describe pod $pod -n $ns
+                  kubectl logs $pod -n $ns
                 done
               fi
             done

--- a/.github/workflows/validate-kind.yaml
+++ b/.github/workflows/validate-kind.yaml
@@ -18,8 +18,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@main
-      - name: Init Flux action
-        uses: fluxcd/flux2/action@v2.3.0
+      - name: Install Flux
+        run: brew install fluxcd/tap/flux@2.3
       - name: Init Kind action
         uses: helm/kind-action@v1.12.0
         with:

--- a/.github/workflows/validate-kind.yaml
+++ b/.github/workflows/validate-kind.yaml
@@ -2,15 +2,14 @@ name: validate-kind-e2e
 
 on:
   workflow_dispatch:
-  # pull_request:
-  #   types:
-  #     - opened
-  #     - reopened
-  #   branches:
-  #     - 'renovate/**'
-  push:
+  pull_request:
+    types:
+      - opened
+      - reopened
     branches:
-      - feature/add_e2e_kind_action
+      - 'renovate/**'
+    paths:
+    - 'clusters/kind-cluster/**'
 
 jobs:
   kubernetes:

--- a/.github/workflows/validate-kind.yaml
+++ b/.github/workflows/validate-kind.yaml
@@ -76,20 +76,20 @@ jobs:
           kubectl -n alice wait helmrelease --all --for=condition=ready --timeout=10m
           kubectl -n bob wait helmrelease --all --for=condition=ready --timeout=10m
           kubectl -n charlie wait helmrelease --all --for=condition=ready --timeout=10m
-      # - name: Comment with test results
-      #   if: |
-      #     success() &&
-      #     github.event_name == 'pull_request' &&
-      #     contains('refs/heads/renovate', github.ref)
-      #   run: |
-      #     node="alice"
-      #     echo "test results for $node/sqnc-node-test-suite:\n" >> comment.txt
-      #     kubectl logs -n $node job/$node-node-sqnc-node-0-post-install-test-suite >> comment.txt
-      #     echo "test results for $node/sqnc-matchmaker-api-test-suite:\n" >> comment.txt
-      #     kubectl logs -n $node job/$node-sqnc-matchmaker-api-test-suite >> comment.txt
-      #     gh pr comment ${{ github.event.number }} --body-file comment.txt
-      #   env:
-      #     GH_TOKEN: ${{ github.token }}
+      - name: Comment with test results
+        if: |
+          success() &&
+          github.event_name == 'pull_request' &&
+          contains('refs/heads/renovate', github.ref)
+        run: |
+          node="alice"
+          echo "test results for $node/sqnc-node-test-suite:\n" >> comment.txt
+          kubectl logs -n $node job/$node-node-sqnc-node-0-post-install-test-suite >> comment.txt
+          echo "test results for $node/sqnc-matchmaker-api-test-suite:\n" >> comment.txt
+          kubectl logs -n $node job/$node-sqnc-matchmaker-api-test-suite >> comment.txt
+          gh pr comment ${{ github.event.number }} --body-file comment.txt
+        env:
+          GH_TOKEN: ${{ github.token }}
       - name: Return GitOps branch to main
         if: |
           success() &&

--- a/.github/workflows/validate-kind.yaml
+++ b/.github/workflows/validate-kind.yaml
@@ -72,24 +72,19 @@ jobs:
       #     GH_TOKEN: ${{ github.token }}
       - name: Debug Flux controller state
         if: failure()
-        run: |
-          kubectl -n flux-system get all
+        run: kubectl -n flux-system get all
       - name: Debug source-controller logs
         if: failure()
-        run: |
-          kubectl -n flux-system logs deploy/source-controller
+        run: kubectl -n flux-system logs deploy/source-controller
       - name: Debug kustomize-controller logs
         if: failure()
-        run: |
-          kubectl -n flux-system logs deploy/kustomize-controller
+        run: kubectl -n flux-system logs deploy/kustomize-controller
       - name: Debug helm-controller logs
         if: failure()
-        run: |
-          kubectl -n flux-system logs deploy/helm-controller
+        run: kubectl -n flux-system logs deploy/helm-controller
       - name: Report all resources
         if: failure()
-        run: |
-          flux get all --all-namespaces
-      - name: get all svc
+        run: flux get all --all-namespaces
+      - name: Report all services
         if: failure()
         run: kubectl get svc -n kube-system

--- a/.github/workflows/validate-kind.yaml
+++ b/.github/workflows/validate-kind.yaml
@@ -47,14 +47,7 @@ jobs:
           --path=./clusters/kind-cluster/base
       - name: Verify Flux kustomizations
         run: |
-          kubectl -n kube-system wait kustomization/nginx-sync --for=condition=ready --timeout=10m
-          kubectl -n keycloak wait kustomization/keycloak-sync --for=condition=ready --timeout=10m
-          kubectl -n monitoring wait kustomization/monitoring-sync --for=condition=ready --timeout=10m
-          kubectl -n loki wait kustomization/promtail-sync --for=condition=ready --timeout=10m
-          kubectl -n loki wait kustomization/loki-sync --for=condition=ready --timeout=10m
-          kubectl -n alice wait kustomization/alice-sync --for=condition=ready --timeout=10m
-          kubectl -n bob wait kustomization/bob-sync --for=condition=ready --timeout=10m
-          kubectl -n charlie wait kustomization/charlie-sync --for=condition=ready --timeout=10m
+          kubectl wait -A kustomization -l kustomize.toolkit.fluxcd.io/name=flux-system --for=condition=ready
       - name: Verify Helm releases
         run: |
           kubectl -n kube-system wait helmrelease --all --for=condition=ready --timeout=10m
@@ -91,28 +84,30 @@ jobs:
           flux resume kustomization --all
           kubectl wait kustomization --all --all-namespaces --for=condition=ready --timeout=10m
           kubectl wait helmrelease --all --all-namespaces --for=condition=ready --timeout=10m
-      - name: Comment with test results
+      - name: Return results and logs for a node
         if: |
           success() &&
           github.event_name == 'pull_request' &&
           contains('refs/heads/renovate', github.ref)
         run: |
           node="alice"
-          if [ $(flux logs -n $node | grep -Eo "$node-node.$node.+'upgrade'" | tail -n 1) ]; then
-            echo "upgrade test results for $node/sqnc-node-test-suite:\n" >> comment.txt
-            kubectl logs -n $node job/$node-node-sqnc-node-0-post-install-test-suite >> comment.txt || \
-            echo "error querying $node-node-sqnc-node-0-post-install-test-suite" >> comment.txt
+          flux logs -n $node
+          if [ "$(kubectl get -n $node job/$node-node-sqnc-node-0-post-install-test-suite)" 2>/dev/null ]; then
+            if [ "$(flux logs -n $node | grep -Eo "$node-node.$node.+'upgrade'" | tail -n 1)" ]; then
+              echo "upgrade test results for $node/sqnc-node-test-suite:\n"
+              kubectl logs -n $node job/$node-node-sqnc-node-0-post-install-test-suite
+            fi
+          else
+            echo "error querying $node-node-sqnc-node-0-post-install-test-suite"
           fi
-          if [ $(flux logs -n $node | grep -Eo "$node-sqnc-matchmaker-api.+'upgrade'" | tail -n 1) ]; then
-            echo "upgrade test results for $node/sqnc-matchmaker-api-test-suite:\n" >> comment.txt
-            kubectl logs -n $node job/$node-sqnc-matchmaker-api-test-suite >> comment.txt || \
-            echo "error querying $node-sqnc-matchmaker-api-test-suite" >> comment.txt
+          if [ "$(kubectl get -n $node job/$node-sqnc-matchmaker-api-test-suite)" 2>/dev/null ]; then
+            if [ "$(flux logs -n $node | grep -Eo "$node-sqnc-matchmaker-api.+'upgrade'" | tail -n 1)" ]; then
+              echo "upgrade test results for $node/sqnc-matchmaker-api-test-suite:\n"
+              kubectl logs -n $node job/$node-sqnc-matchmaker-api-test-suite
+            fi
+          else
+            echo "error querying $node-sqnc-matchmaker-api-test-suite"
           fi
-          if [ -f comment.txt ]; then
-            gh pr comment ${{ github.event.number }} --body-file comment.txt
-          fi
-        env:
-          GH_TOKEN: ${{ github.token }}
       - name: Return GitOps branch to main
         if: |
           success() &&

--- a/.github/workflows/validate-kind.yaml
+++ b/.github/workflows/validate-kind.yaml
@@ -84,30 +84,31 @@ jobs:
           flux resume kustomization --all
           kubectl wait kustomization --all --all-namespaces --for=condition=ready --timeout=10m
           kubectl wait helmrelease --all --all-namespaces --for=condition=ready --timeout=10m
-      - name: Return results and logs for a node
+      - name: Return test results
         if: |
           success() &&
           github.event_name == 'pull_request' &&
           contains('refs/heads/renovate', github.ref)
         run: |
-          node="alice"
-          flux logs -n $node
-          if [ "$(kubectl get -n $node job/$node-node-sqnc-node-0-post-install-test-suite)" 2>/dev/null ]; then
-            if [ "$(flux logs -n $node | grep -Eo "$node-node.$node.+'upgrade'" | tail -n 1)" ]; then
-              echo "upgrade test results for $node/sqnc-node-test-suite:\n"
-              kubectl logs -n $node job/$node-node-sqnc-node-0-post-install-test-suite
-            fi
-          else
-            echo "error querying $node-node-sqnc-node-0-post-install-test-suite"
-          fi
-          if [ "$(kubectl get -n $node job/$node-sqnc-matchmaker-api-test-suite)" 2>/dev/null ]; then
-            if [ "$(flux logs -n $node | grep -Eo "$node-sqnc-matchmaker-api.+'upgrade'" | tail -n 1)" ]; then
-              echo "upgrade test results for $node/sqnc-matchmaker-api-test-suite:\n"
-              kubectl logs -n $node job/$node-sqnc-matchmaker-api-test-suite
-            fi
-          else
-            echo "error querying $node-sqnc-matchmaker-api-test-suite"
-          fi
+          namespaces=$(kubectl get namespaces -A | tail -n +2 | awk '{print $1}')
+          for ns in $(echo $namespaces); do
+            for job in $(kubectl get jobs -n $ns 2>/dev/null | tail -n +2 | awk {'print $1'}); do
+              hook=$(kubectl get job/$job -n $ns -o jsonpath="{.metadata.annotations.helm\.sh/hook }" | grep -Eo "test")
+              kubectl wait job/$job -n $ns --for=condition=Complete 1>/dev/null
+              if [ ! -z "$hook" ]; then
+                echo "\nHelm tests for $job:"
+                kubectl logs job/$job -n $ns
+                pods=$(kubectl get pods --selector=job-name=$job -n $ns | tail -n +2 | awk '{print $1}')
+                for pod in $(echo $pods); do
+                  phase=$(kubectl get pods $pod -n $ns --no-headers -o custom-columns=":status.phase")
+                  if [ "$phase" = "Failed" ]; then
+                    kubectl describe pod $pod -n $ns
+                    kubectl logs $pod -n $ns
+                  fi
+                done
+              fi
+            done
+          done
       - name: Return GitOps branch to main
         if: |
           success() &&
@@ -125,7 +126,7 @@ jobs:
           namespaces=$(kubectl get namespaces -A | tail -n +2 | awk '{print $1}')
           for ns in $(echo $namespaces); do
             pods=$(kubectl get pods -o jsonpath='{range .items[?(@.status.containerStatuses[-1:].state.waiting)]}{.metadata.name}: {@.status.containerStatuses[*].state.waiting.reason}{"\n"}{end}' -n $ns | tail -n +2 | awk '{print $1}')
-            if [ ! -z $pods ]; then
+            if [ ! -z "$pods" ]; then
               for pod in $(echo $pods); do
                 kubectl describe pod $pod -n $ns
                 kubectl logs $pod -n $ns

--- a/.github/workflows/validate-kind.yaml
+++ b/.github/workflows/validate-kind.yaml
@@ -31,7 +31,23 @@ jobs:
           config: ./scripts/kind-cluster-config.yaml
       - name: Install Flux to cluster
         run: flux install
+      - name: Configure Git
+        run: |
+          git config user.name ${GITHUB_ACTOR}
+          git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+      - name: Patch GitOps branch to match PR
+        if: |
+          github.event_name == 'pull_request' &&
+          contains('refs/heads/renovate', github.ref)
+        run: |
+          patch=${GITHUB_REF#refs/heads/}
+          sed -i -r "s#(branch:).*#\1 $patch#" \
+            ./clusters/kind-cluster/base/flux-system/gotk-sync.yaml
+          git add ./clusters/kind-cluster/base/flux-system/gotk-sync.yaml
+          git commit -am "Patch GitOps branch to match PR"
+          git push -u origin $patch
       - name: Source repository and reconcile
+        if: success()
         run: |
           flux create source git flux-system \
           --url=${{ github.event.repository.html_url }} \
@@ -61,6 +77,10 @@ jobs:
           kubectl -n bob wait helmrelease --all --for=condition=ready --timeout=10m
           kubectl -n charlie wait helmrelease --all --for=condition=ready --timeout=10m
       # - name: Comment with test results
+      #   if: |
+      #     success() &&
+      #     github.event_name == 'pull_request' &&
+      #     contains('refs/heads/renovate', github.ref)
       #   run: |
       #     node="alice"
       #     echo "test results for $node/sqnc-node-test-suite:\n" >> comment.txt
@@ -70,6 +90,17 @@ jobs:
       #     gh pr comment ${{ github.event.number }} --body-file comment.txt
       #   env:
       #     GH_TOKEN: ${{ github.token }}
+      - name: Return GitOps branch to main
+        if: |
+          success() &&
+          github.event_name == 'pull_request' &&
+          contains('refs/heads/renovate', github.ref)
+        run: |
+          sed -i -r "s#(branch:).*#\1 main#" \
+            ./clusters/kind-cluster/base/flux-system/gotk-sync.yaml
+          git add ./clusters/kind-cluster/base/flux-system/gotk-sync.yaml
+          git commit -am "Return GitOps branch to main"
+          git push -u origin ${GITHUB_REF#refs/heads/}
       - name: Debug Flux controller state
         if: failure()
         run: kubectl -n flux-system get all

--- a/scripts/add-kind-cluster.sh
+++ b/scripts/add-kind-cluster.sh
@@ -29,6 +29,11 @@ if [ "${running}" != 'true' ]; then
 fi
 
 # create a cluster with the local registry enabled in containerd
+config_file="kind-cluster-config.yaml"
+if [ -f "$(dirname $0)/$config_file" ]; then
+  echo "Using $config_file"
+  kind create cluster --name sqnc-flux-infra --config="$(dirname $0)/$config_file"
+else
 cat <<EOF | kind create cluster --name sqnc-flux-infra --config=-
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
@@ -53,6 +58,7 @@ nodes:
     protocol: tcp
 - role: worker
 EOF
+fi
 
 # connect the registry to the cluster network
 # (the network may already be connected)

--- a/scripts/kind-cluster-config.yaml
+++ b/scripts/kind-cluster-config.yaml
@@ -1,0 +1,22 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+containerdConfigPatches:
+- |-
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:5000"]
+    endpoint = ["http://kind-registry:5000"]
+nodes:
+- role: control-plane
+  kubeadmConfigPatches:
+  - |
+    kind: InitConfiguration
+    nodeRegistration:
+      kubeletExtraArgs:
+        node-labels: "ingress-ready=true"
+  extraPortMappings:
+  - containerPort: 80
+    hostPort: 3080
+    protocol: tcp
+  - containerPort: 443
+    hostPort: 3443
+    protocol: tcp
+- role: worker


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [x] Feature

## Linked tickets

SQNC-143
SQNC-144

## High level description

This PR borrows from Flux's own E2E example with Kind, swaps out their action for a Homebrew stage to install v2.3.0, but largely maintains the same overall structure. A GitOps run-through of the main branch is performed first and then we switch out the sourced branch for the one used in the Renovate PR, force the reconciliation and watch for the release to upgrade. If specific releases are logged as having upgraded, then we write their continuous integration tests to a PR comment. This only applies to our own charts at present. Multiple stages have been included to help debug the above process on failure, in particular the errors on any given pod should result in `kubectl describe` and `kubectl logs` being collected for it.

## Describe alternatives you've considered

At David's suggestion, I've modified the script we use for creating Kind clusters locally to check for the existence of the same configuration used in the workflow. For the moment, the script doesn't take user input via `getopts` to change the registry port or name; the defaults are used in both places. Were that to change, then it might be appropriate to have a flag to ignore or keep existing configuration files.

When upgrading Flux to v2.5.1, it should be possible to replace the Homebrew action with Flux's own or else just pin `brew install` to a good version as I've done here.

## Operational impact

It will generate a lot of PRs initially. Fine-tuning will be necessary, mostly through the use of package rules.

Any PRs triggered for _other_ clusters will also require investigation, as this workflow should only trigger on the path for the Kind cluster itself.