### PR TITLE
Wait once on releases for all namespaces

### DIFF
--- a/.github/workflows/validate-kind.yaml
+++ b/.github/workflows/validate-kind.yaml
@@ -56,13 +56,7 @@ jobs:
           kubectl wait -A kustomization -l kustomize.toolkit.fluxcd.io/name=flux-system --for=condition=ready --timeout=3m
       - name: Verify Helm releases
         run: |
-          kubectl -n kube-system wait helmrelease --all --for=condition=ready --timeout=10m
-          kubectl -n keycloak wait helmrelease --all --for=condition=ready --timeout=10m
-          kubectl -n monitoring wait helmrelease --all --for=condition=ready --timeout=10m
-          kubectl -n loki wait helmrelease --all --for=condition=ready --timeout=10m
-          kubectl -n alice wait helmrelease --all --for=condition=ready --timeout=10m
-          kubectl -n bob wait helmrelease --all --for=condition=ready --timeout=10m
-          kubectl -n charlie wait helmrelease --all --for=condition=ready --timeout=10m
+          kubectl wait -A helmrelease --all --for=condition=ready --timeout=10m
       - name: Patch GitOps branch to match PR
         if: |
           success() &&


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [x] Bug Fix
- [ ] Chore
- [ ] Feature
- [ ] Documentation Update
- [ ] Code style update (formatting, local variables)
- [ ] Breaking Change (fix or feature that would cause existing functionality to change)

## High level description

Specifying the releases to wait for was the wrong approach, as some are more likely to change during development than others. Instead, we ought to just wait on all releases to be ready across all namespaces.