### PR TITLE
Adding otlp http port as it is required

### DIFF
--- a/clusters/sqnc-staging/monitoring/jaeger/values.yaml
+++ b/clusters/sqnc-staging/monitoring/jaeger/values.yaml
@@ -23,6 +23,9 @@ collector:
       grpc:
         name: otlp-grpc
         port: 4317
+      http:
+        name: otlp-http
+        port: 4318
 query:
   enabled: true
   basePath: /jaeger


### PR DESCRIPTION
# Pull Request

## Checklist
- [X] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [X] Bug Fix

## Linked tickets

SQNC-160

## High level description

There is a bug in the helm chart that required both http and grpc service ports to be added in the values otherwise helm tries to render svc ports that are unnamed.

## Detailed description

<!-- A detailed description of the feature and if possible describe how has been implemented. -->


## Describe alternatives you've considered

<!-- A clear and concise description of the alternative solutions you've considered. Be sure to explain why the existing customisability isn't suitable for this feature. -->

## Operational impact

<!--- A description of any operational considerations associated with the change. Is there anything in particular we should be looking at when deploying the change to make sure it is working as intended. If something goes wrong will any special actions be needed to revert the change. -->

## Additional context

<!-- Add any other context or screenshots about the feature request here. -->
