### PR TITLE
Repair E2E Kind workflow

### DIFF
--- a/.github/workflows/validate-kind.yaml
+++ b/.github/workflows/validate-kind.yaml
@@ -17,6 +17,10 @@ on:
     paths:
       - 'clusters/kind-cluster/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   kubernetes:
     runs-on: ubuntu-latest

--- a/.github/workflows/validate-kind.yaml
+++ b/.github/workflows/validate-kind.yaml
@@ -80,8 +80,11 @@ jobs:
           --username=${GITHUB_ACTOR} \
           --password=${{ secrets.GITHUB_TOKEN }}
           flux resume kustomization --all
-          kubectl wait kustomization --all --all-namespaces --for=condition=ready --timeout=10m
+          message=$(echo ${GITHUB_REF#refs/heads/}"@sha1:"$(git log -n 1 ${GITHUB_REF#refs/heads/} --pretty=format:"%H"))
+          kubectl wait kustomization --all --all-namespaces --for='jsonpath={.status.conditions[?(@.type=="Ready")].message}=Applied revision: '"$message" --timeout=10m
+          kubectl get kustomizations -A
           kubectl wait helmrelease --all --all-namespaces --for=condition=ready --timeout=10m
+          kubectl get helmreleases -A
       - name: Return test results
         if: success()
         run: |

--- a/.github/workflows/validate-kind.yaml
+++ b/.github/workflows/validate-kind.yaml
@@ -90,19 +90,22 @@ jobs:
         run: |
           namespaces=$(kubectl get namespaces -A | tail -n +2 | awk '{print $1}')
           for ns in $(echo $namespaces); do
-            for job in $(kubectl get jobs -n $ns 2>/dev/null | tail -n +2 | awk {'print $1'}); do
-              hook=$(kubectl get job/$job -n $ns -o jsonpath="{.metadata.annotations.helm\.sh/hook }" | grep -Eo "test")
-              kubectl wait job/$job -n $ns --for=condition=Complete 1>/dev/null
-              if [ ! -z "$hook" ]; then
-                echo "\nHelm tests for $job:"
-                kubectl logs job/$job -n $ns
-                pods=$(kubectl get pods --selector=job-name=$job -n $ns | tail -n +2 | awk '{print $1}')
-                for pod in $(echo $pods); do
-                  kubectl describe pod $pod -n $ns
-                  kubectl logs $pod -n $ns
-                done
-              fi
-            done
+            jobs=$(kubectl get jobs -n $ns --ignore-not-found | grep -v "cron" | tail -n +2 | awk {'print $1'})
+            if [ ! -z "$jobs" ]; then
+              echo "Jobs found:"
+              echo "$jobs"
+              for job in $(echo $jobs); do
+                hook=$(kubectl get job/$job -n $ns -o jsonpath="{.metadata.annotations.helm\.sh/hook }" | grep -Eo "test")
+                if [ ! -z "$hook" ]; then
+                  echo "Helm tests for $job:"
+                  kubectl logs job/$job -n $ns --all-containers
+                  pods=$(kubectl get pods --selector=job-name=$job -n $ns --ignore-not-found | tail -n +2 | awk '{print $1}')
+                  for pod in $(echo $pods); do
+                    kubectl describe pod $pod -n $ns
+                  done
+                fi
+              done
+            fi
           done
       - name: Return GitOps branch to main
         if: success()

--- a/renovate.config.js
+++ b/renovate.config.js
@@ -14,7 +14,7 @@ module.exports = (config = {}) => {
   return {
     $schema: "https://docs.renovatebot.com/renovate-schema.json",
     baseBranches: [
-      "dev",
+      "main",
     ],
     extends: [
       ":timezone(Europe/London)"


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [x] Bug Fix

## Linked tickets

SQNC-143/4

## High level description

This PR fixes the end-to-end Kind test of Renovate PRs. Two edge cases were identified while debugging:
1. The `kubectl wait` command intended to watch for the updated kustomizations (e.g. with the respective revision to the Renovate branch) can actually catch the existing kustomizations for the main branch instead (as they happen to be "Ready"),
2. Any finished cronjobs listed for a namespace are culled quickly but they're still being included in the list used by the loop, resulting in a failure when they can't be found.

With the first scenario, the `kubectl wait kustomization` command used is now pinned to the expected revision of the feature branch (using the "message" field). To address the second failure case, cronjobs simply aren't included in the list of jobs returned for the loop.