### PR TITLE
Add OAuth scopes to KIND realms

### DIFF
--- a/clusters/kind-cluster/alice/open-api-merger/values.yaml
+++ b/clusters/kind-cluster/alice/open-api-merger/values.yaml
@@ -27,6 +27,20 @@ securitySchema:
       - clientCredentials
     tokenUrl: "/auth/realms/alice/protocol/openid-connect/token"
     refreshUrl: "/auth/realms/alice/protocol/openid-connect/token"
-    scopes: {}
+    scopes: 
+      demandA:read: "Read demandA"
+      demandA:prepare: "Prepare demandA"
+      demandA:create: "Create demandA"
+      demandA:comment: "Comment on demandA"
+      demandB:read: "Read demandB"
+      demandB:prepare: "Prepare demandB"
+      demandB:create: "Create demandB"
+      demandB:comment: "Comment on demandB"
+      match2:read: "Read match2"
+      match2:prepare: "Prepare match2"
+      match2:propose: "Propose match2"
+      match2:cancel: "Cancel match2"
+      match2:accept: "Accept match2"
+      match2:reject: "Reject match2"
 podAnnotations:
   instrumentation.opentelemetry.io/inject-nodejs: "monitoring/nodejs-instrumentation"

--- a/clusters/kind-cluster/alice/sqnc-matchmaker-api/release.yaml
+++ b/clusters/kind-cluster/alice/sqnc-matchmaker-api/release.yaml
@@ -21,7 +21,7 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: digicatapult
-      version: "3.0.2"
+      version: "4.0.0"
   valuesFrom:
     - kind: ConfigMap
       name: alice-values

--- a/clusters/kind-cluster/base/flux-system/gotk-sync.yaml
+++ b/clusters/kind-cluster/base/flux-system/gotk-sync.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: feat/realm-scopes
+    branch: main
   url: https://github.com/digicatapult/sqnc-flux-infra.git
 
 ---

--- a/clusters/kind-cluster/base/flux-system/gotk-sync.yaml
+++ b/clusters/kind-cluster/base/flux-system/gotk-sync.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: main
+    branch: feat/realm-scopes
   url: https://github.com/digicatapult/sqnc-flux-infra.git
 
 ---

--- a/clusters/kind-cluster/bob/open-api-merger/values.yaml
+++ b/clusters/kind-cluster/bob/open-api-merger/values.yaml
@@ -27,6 +27,20 @@ securitySchema:
       - clientCredentials
     tokenUrl: "/auth/realms/bob/protocol/openid-connect/token"
     refreshUrl: "/auth/realms/bob/protocol/openid-connect/token"
-    scopes: {}
+    scopes: 
+      demandA:read: "Read demandA"
+      demandA:prepare: "Prepare demandA"
+      demandA:create: "Create demandA"
+      demandA:comment: "Comment on demandA"
+      demandB:read: "Read demandB"
+      demandB:prepare: "Prepare demandB"
+      demandB:create: "Create demandB"
+      demandB:comment: "Comment on demandB"
+      match2:read: "Read match2"
+      match2:prepare: "Prepare match2"
+      match2:propose: "Propose match2"
+      match2:cancel: "Cancel match2"
+      match2:accept: "Accept match2"
+      match2:reject: "Reject match2"
 podAnnotations:
   instrumentation.opentelemetry.io/inject-nodejs: "monitoring/nodejs-instrumentation"

--- a/clusters/kind-cluster/bob/sqnc-matchmaker-api/release.yaml
+++ b/clusters/kind-cluster/bob/sqnc-matchmaker-api/release.yaml
@@ -21,7 +21,7 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: digicatapult
-      version: "3.0.2"
+      version: "4.0.0"
   valuesFrom:
     - kind: ConfigMap
       name: bob-values

--- a/clusters/kind-cluster/charlie/open-api-merger/values.yaml
+++ b/clusters/kind-cluster/charlie/open-api-merger/values.yaml
@@ -27,6 +27,20 @@ securitySchema:
       - clientCredentials
     tokenUrl: "/auth/realms/charlie/protocol/openid-connect/token"
     refreshUrl: "/auth/realms/charlie/protocol/openid-connect/token"
-    scopes: {}
+    scopes: 
+      demandA:read: "Read demandA"
+      demandA:prepare: "Prepare demandA"
+      demandA:create: "Create demandA"
+      demandA:comment: "Comment on demandA"
+      demandB:read: "Read demandB"
+      demandB:prepare: "Prepare demandB"
+      demandB:create: "Create demandB"
+      demandB:comment: "Comment on demandB"
+      match2:read: "Read match2"
+      match2:prepare: "Prepare match2"
+      match2:propose: "Propose match2"
+      match2:cancel: "Cancel match2"
+      match2:accept: "Accept match2"
+      match2:reject: "Reject match2"
 podAnnotations:
   instrumentation.opentelemetry.io/inject-nodejs: "monitoring/nodejs-instrumentation"

--- a/clusters/kind-cluster/charlie/sqnc-matchmaker-api/release.yaml
+++ b/clusters/kind-cluster/charlie/sqnc-matchmaker-api/release.yaml
@@ -21,7 +21,7 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: digicatapult
-      version: "3.0.2"
+      version: "4.0.0"
   valuesFrom:
     - kind: ConfigMap
       name: charlie-values

--- a/clusters/kind-cluster/keycloak/realms.yaml
+++ b/clusters/kind-cluster/keycloak/realms.yaml
@@ -494,17 +494,157 @@ data:
             "acr",
             "roles",
             "profile",
-            "email"
+            "email",
+            "demandA:read",
+            "demandA:prepare",
+            "demandA:create",
+            "demandA:comment",
+            "match2:read",
+            "match2:accept",
+            "match2:reject"
           ],
           "optionalClientScopes": [
             "address",
             "phone",
             "offline_access",
-            "microprofile-jwt"
+            "microprofile-jwt",
+            "demandB:read",
+            "demandB:prepare",
+            "demandB:create",
+            "demandB:comment",
+            "match2:prepare",
+            "match2:propose",
+            "match2:cancel"
           ]
         }
       ],
       "clientScopes": [
+        {
+          "name": "demandA:read",
+          "protocol": "openid-connect",
+          "description": "Read demandA",
+          "attributes": {
+            "include.in.token.scope": "true",
+            "display.on.consent.screen": "true"
+          }
+        },
+        {
+          "name": "demandA:prepare",
+          "protocol": "openid-connect",
+          "description": "Prepare demandA",
+          "attributes": {
+            "include.in.token.scope": "true",
+            "display.on.consent.screen": "true"
+          }
+        },
+        {
+          "name": "demandA:create",
+          "protocol": "openid-connect",
+          "description": "Create demandA",
+          "attributes": {
+            "include.in.token.scope": "true",
+            "display.on.consent.screen": "true"
+          }
+        },
+        {
+          "name": "demandA:comment",
+          "protocol": "openid-connect",
+          "description": "Comment on demandA",
+          "attributes": {
+            "include.in.token.scope": "true",
+            "display.on.consent.screen": "true"
+          }
+        },
+        {
+          "name": "demandB:read",
+          "protocol": "openid-connect",
+          "description": "Read demandB",
+          "attributes": {
+            "include.in.token.scope": "true",
+            "display.on.consent.screen": "true"
+          }
+        },
+        {
+          "name": "demandB:prepare",
+          "protocol": "openid-connect",
+          "description": "Prepare demandB",
+          "attributes": {
+            "include.in.token.scope": "true",
+            "display.on.consent.screen": "true"
+          }
+        },
+        {
+          "name": "demandB:create",
+          "protocol": "openid-connect",
+          "description": "Create demandB",
+          "attributes": {
+            "include.in.token.scope": "true",
+            "display.on.consent.screen": "true"
+          }
+        },
+        {
+          "name": "demandB:comment",
+          "protocol": "openid-connect",
+          "description": "Comment on demandB",
+          "attributes": {
+            "include.in.token.scope": "true",
+            "display.on.consent.screen": "true"
+          }
+        },
+        {
+          "name": "match2:read",
+          "protocol": "openid-connect",
+          "description": "Read match2",
+          "attributes": {
+            "include.in.token.scope": "true",
+            "display.on.consent.screen": "true"
+          }
+        },
+        {
+          "name": "match2:prepare",
+          "protocol": "openid-connect",
+          "description": "Prepare match2",
+          "attributes": {
+            "include.in.token.scope": "true",
+            "display.on.consent.screen": "true"
+          }
+        },
+        {
+          "name": "match2:propose",
+          "protocol": "openid-connect",
+          "description": "Propose match2",
+          "attributes": {
+            "include.in.token.scope": "true",
+            "display.on.consent.screen": "true"
+          }
+        },
+        {
+          "name": "match2:cancel",
+          "protocol": "openid-connect",
+          "description": "Cancel match2",
+          "attributes": {
+            "include.in.token.scope": "true",
+            "display.on.consent.screen": "true"
+          }
+        },
+        {
+          "name": "match2:accept",
+          "protocol": "openid-connect",
+          "description": "Accept match2",
+          "attributes": {
+            "include.in.token.scope": "true",
+            "display.on.consent.screen": "true"
+          }
+        },
+        {
+          "name": "match2:reject",
+          "protocol": "openid-connect",
+          "description": "Reject match2",
+          "attributes": {
+            "include.in.token.scope": "true",
+            "display.on.consent.screen": "true"
+          }
+        },
         {
           "name": "roles",
           "description": "OpenID Connect scope for add user roles to the access token",
@@ -4166,17 +4306,157 @@ data:
             "acr",
             "roles",
             "profile",
-            "email"
+            "email",
+            "demandB:read",
+            "demandB:prepare",
+            "demandB:create",
+            "demandB:comment",
+            "match2:read",
+            "match2:accept",
+            "match2:reject"
           ],
           "optionalClientScopes": [
             "address",
             "phone",
             "offline_access",
-            "microprofile-jwt"
+            "microprofile-jwt",
+            "demandA:read",
+            "demandA:prepare",
+            "demandA:create",
+            "demandA:comment",
+            "match2:prepare",
+            "match2:propose",
+            "match2:cancel"
           ]
         }
       ],
       "clientScopes": [
+        {
+          "name": "demandA:read",
+          "protocol": "openid-connect",
+          "description": "Read demandA",
+          "attributes": {
+            "include.in.token.scope": "true",
+            "display.on.consent.screen": "true"
+          }
+        },
+        {
+          "name": "demandA:prepare",
+          "protocol": "openid-connect",
+          "description": "Prepare demandA",
+          "attributes": {
+            "include.in.token.scope": "true",
+            "display.on.consent.screen": "true"
+          }
+        },
+        {
+          "name": "demandA:create",
+          "protocol": "openid-connect",
+          "description": "Create demandA",
+          "attributes": {
+            "include.in.token.scope": "true",
+            "display.on.consent.screen": "true"
+          }
+        },
+        {
+          "name": "demandA:comment",
+          "protocol": "openid-connect",
+          "description": "Comment on demandA",
+          "attributes": {
+            "include.in.token.scope": "true",
+            "display.on.consent.screen": "true"
+          }
+        },
+        {
+          "name": "demandB:read",
+          "protocol": "openid-connect",
+          "description": "Read demandB",
+          "attributes": {
+            "include.in.token.scope": "true",
+            "display.on.consent.screen": "true"
+          }
+        },
+        {
+          "name": "demandB:prepare",
+          "protocol": "openid-connect",
+          "description": "Prepare demandB",
+          "attributes": {
+            "include.in.token.scope": "true",
+            "display.on.consent.screen": "true"
+          }
+        },
+        {
+          "name": "demandB:create",
+          "protocol": "openid-connect",
+          "description": "Create demandB",
+          "attributes": {
+            "include.in.token.scope": "true",
+            "display.on.consent.screen": "true"
+          }
+        },
+        {
+          "name": "demandB:comment",
+          "protocol": "openid-connect",
+          "description": "Comment on demandB",
+          "attributes": {
+            "include.in.token.scope": "true",
+            "display.on.consent.screen": "true"
+          }
+        },
+        {
+          "name": "match2:read",
+          "protocol": "openid-connect",
+          "description": "Read match2",
+          "attributes": {
+            "include.in.token.scope": "true",
+            "display.on.consent.screen": "true"
+          }
+        },
+        {
+          "name": "match2:prepare",
+          "protocol": "openid-connect",
+          "description": "Prepare match2",
+          "attributes": {
+            "include.in.token.scope": "true",
+            "display.on.consent.screen": "true"
+          }
+        },
+        {
+          "name": "match2:propose",
+          "protocol": "openid-connect",
+          "description": "Propose match2",
+          "attributes": {
+            "include.in.token.scope": "true",
+            "display.on.consent.screen": "true"
+          }
+        },
+        {
+          "name": "match2:cancel",
+          "protocol": "openid-connect",
+          "description": "Cancel match2",
+          "attributes": {
+            "include.in.token.scope": "true",
+            "display.on.consent.screen": "true"
+          }
+        },
+        {
+          "name": "match2:accept",
+          "protocol": "openid-connect",
+          "description": "Accept match2",
+          "attributes": {
+            "include.in.token.scope": "true",
+            "display.on.consent.screen": "true"
+          }
+        },
+        {
+          "name": "match2:reject",
+          "protocol": "openid-connect",
+          "description": "Reject match2",
+          "attributes": {
+            "include.in.token.scope": "true",
+            "display.on.consent.screen": "true"
+          }
+        },
         {
           "name": "roles",
           "description": "OpenID Connect scope for add user roles to the access token",
@@ -7838,17 +8118,157 @@ data:
             "acr",
             "roles",
             "profile",
-            "email"
+            "email",
+            "match2:prepare",
+            "match2:propose",
+            "match2:cancel",
+            "match2:read",
+            "demandA:read",
+            "demandB:read"
           ],
           "optionalClientScopes": [
             "address",
             "phone",
             "offline_access",
-            "microprofile-jwt"
+            "microprofile-jwt",
+            "demandA:prepare",
+            "demandA:create",
+            "demandA:comment",
+            "demandB:prepare",
+            "demandB:create",
+            "demandB:comment",
+            "match2:accept",
+            "match2:reject"
           ]
         }
       ],
       "clientScopes": [
+        {
+          "name": "demandA:read",
+          "protocol": "openid-connect",
+          "description": "Read demandA",
+          "attributes": {
+            "include.in.token.scope": "true",
+            "display.on.consent.screen": "true"
+          }
+        },
+        {
+          "name": "demandA:prepare",
+          "protocol": "openid-connect",
+          "description": "Prepare demandA",
+          "attributes": {
+            "include.in.token.scope": "true",
+            "display.on.consent.screen": "true"
+          }
+        },
+        {
+          "name": "demandA:create",
+          "protocol": "openid-connect",
+          "description": "Create demandA",
+          "attributes": {
+            "include.in.token.scope": "true",
+            "display.on.consent.screen": "true"
+          }
+        },
+        {
+          "name": "demandA:comment",
+          "protocol": "openid-connect",
+          "description": "Comment on demandA",
+          "attributes": {
+            "include.in.token.scope": "true",
+            "display.on.consent.screen": "true"
+          }
+        },
+        {
+          "name": "demandB:read",
+          "protocol": "openid-connect",
+          "description": "Read demandB",
+          "attributes": {
+            "include.in.token.scope": "true",
+            "display.on.consent.screen": "true"
+          }
+        },
+        {
+          "name": "demandB:prepare",
+          "protocol": "openid-connect",
+          "description": "Prepare demandB",
+          "attributes": {
+            "include.in.token.scope": "true",
+            "display.on.consent.screen": "true"
+          }
+        },
+        {
+          "name": "demandB:create",
+          "protocol": "openid-connect",
+          "description": "Create demandB",
+          "attributes": {
+            "include.in.token.scope": "true",
+            "display.on.consent.screen": "true"
+          }
+        },
+        {
+          "name": "demandB:comment",
+          "protocol": "openid-connect",
+          "description": "Comment on demandB",
+          "attributes": {
+            "include.in.token.scope": "true",
+            "display.on.consent.screen": "true"
+          }
+        },
+        {
+          "name": "match2:read",
+          "protocol": "openid-connect",
+          "description": "Read match2",
+          "attributes": {
+            "include.in.token.scope": "true",
+            "display.on.consent.screen": "true"
+          }
+        },
+        {
+          "name": "match2:prepare",
+          "protocol": "openid-connect",
+          "description": "Prepare match2",
+          "attributes": {
+            "include.in.token.scope": "true",
+            "display.on.consent.screen": "true"
+          }
+        },
+        {
+          "name": "match2:propose",
+          "protocol": "openid-connect",
+          "description": "Propose match2",
+          "attributes": {
+            "include.in.token.scope": "true",
+            "display.on.consent.screen": "true"
+          }
+        },
+        {
+          "name": "match2:cancel",
+          "protocol": "openid-connect",
+          "description": "Cancel match2",
+          "attributes": {
+            "include.in.token.scope": "true",
+            "display.on.consent.screen": "true"
+          }
+        },
+        {
+          "name": "match2:accept",
+          "protocol": "openid-connect",
+          "description": "Accept match2",
+          "attributes": {
+            "include.in.token.scope": "true",
+            "display.on.consent.screen": "true"
+          }
+        },
+        {
+          "name": "match2:reject",
+          "protocol": "openid-connect",
+          "description": "Reject match2",
+          "attributes": {
+            "include.in.token.scope": "true",
+            "display.on.consent.screen": "true"
+          }
+        },
         {
           "name": "roles",
           "description": "OpenID Connect scope for add user roles to the access token",

--- a/docs/keycloak.md
+++ b/docs/keycloak.md
@@ -15,4 +15,4 @@ The Keycloak instance comes with a realm per persona named `alice`, `bob` and `c
 
 ### Authenticating swagger
 
-A client exists in each realm called `sequence` which supports the clientCredentials flow. When visiting any of the swagger interfaces, for example `http://localhost:3080/alice/swagger`, you will need to authenticate by clicking `Authorize`. The "secret" for all three realms is configured to be the value `secret`. Once authenticated you will then be able to make calls through the swagger interface.
+A client exists in each realm called `sequence` which supports the clientCredentials flow. When visiting any of the swagger interfaces, for example `http://localhost:3080/alice/swagger/`, you will need to authenticate by clicking `Authorize`. The "secret" for all three realms is configured to be the value `secret`. Once authenticated you will then be able to make calls through the swagger interface.


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

- [x] Chore

## Linked tickets

https://digicatapult.atlassian.net/browse/SQNC-30

## High level description

Add OAuth scopes to each realm's sequence client. Sensible default scopes are included in tokens for each persona. Each persona can optionally request any scope.
See https://github.com/digicatapult/sqnc-matchmaker-api/pull/635 for scopes added to matchmaker routes

## Detailed description
Video shows:
- Default scope for Alice lets you read `demandA` but not `demandB`
- If you authorise with `demandB:read` token selected, you can read `demandB`


https://github.com/user-attachments/assets/b4c2b17d-21f7-469c-955e-34c9fbd8ff3a

