### PR TITLE
Update Kind services for PostgreSQL v16

### DIFF
--- a/clusters/kind-cluster/alice/sqnc-identity-service/release.yaml
+++ b/clusters/kind-cluster/alice/sqnc-identity-service/release.yaml
@@ -16,7 +16,7 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: digicatapult
-      version: "5.1.1"
+      version: "5.1.2"
   valuesFrom:
     - kind: ConfigMap
       name: alice-values

--- a/clusters/kind-cluster/alice/sqnc-matchmaker-api/release.yaml
+++ b/clusters/kind-cluster/alice/sqnc-matchmaker-api/release.yaml
@@ -21,7 +21,7 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: digicatapult
-      version: "4.0.0"
+      version: "4.0.2"
   valuesFrom:
     - kind: ConfigMap
       name: alice-values

--- a/clusters/kind-cluster/base/flux-system/gotk-sync.yaml
+++ b/clusters/kind-cluster/base/flux-system/gotk-sync.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: main
+    branch: chore/upgrade_kind_services_with_postgresql_v16
   url: https://github.com/digicatapult/sqnc-flux-infra.git
 
 ---

--- a/clusters/kind-cluster/base/flux-system/gotk-sync.yaml
+++ b/clusters/kind-cluster/base/flux-system/gotk-sync.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: chore/upgrade_kind_services_with_postgresql_v16
+    branch: main
   url: https://github.com/digicatapult/sqnc-flux-infra.git
 
 ---

--- a/clusters/kind-cluster/bob/sqnc-identity-service/release.yaml
+++ b/clusters/kind-cluster/bob/sqnc-identity-service/release.yaml
@@ -16,7 +16,7 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: digicatapult
-      version: "5.1.1"
+      version: "5.1.2"
   valuesFrom:
     - kind: ConfigMap
       name: bob-values

--- a/clusters/kind-cluster/bob/sqnc-matchmaker-api/release.yaml
+++ b/clusters/kind-cluster/bob/sqnc-matchmaker-api/release.yaml
@@ -21,7 +21,7 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: digicatapult
-      version: "4.0.0"
+      version: "4.0.2"
   valuesFrom:
     - kind: ConfigMap
       name: bob-values

--- a/clusters/kind-cluster/charlie/sqnc-identity-service/release.yaml
+++ b/clusters/kind-cluster/charlie/sqnc-identity-service/release.yaml
@@ -16,7 +16,7 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: digicatapult
-      version: "5.1.1"
+      version: "5.1.2"
   valuesFrom:
     - kind: ConfigMap
       name: charlie-values

--- a/clusters/kind-cluster/charlie/sqnc-matchmaker-api/release.yaml
+++ b/clusters/kind-cluster/charlie/sqnc-matchmaker-api/release.yaml
@@ -21,7 +21,7 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: digicatapult
-      version: "4.0.0"
+      version: "4.0.2"
   valuesFrom:
     - kind: ConfigMap
       name: charlie-values


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [x] Bug Fix
- [x] Breaking Change (fix or feature that would cause existing functionality to change)

## Linked tickets

SQNC-157

## High level description

We've swapped out PostgreSQL v17 for v16 in the matchmaker API and identity service charts, which is something that Renovate workflows won't be able to handle. We can't downgrade major versions of the Bitnami sub-chart, just as we can't upgrade. At present, however, Renovate will be installing v17 as part of the workflow to checkout main and then it'll be reconciling new chart versions that use v16, resulting in a failed release. Pinning the updated chart in Kind should prevent Renovate from failing specifically for these two charts.