### PR TITLE
Add attachment API to production

### DIFF
--- a/clusters/l3-sqnc/base/flux-system/gotk-sync.yaml
+++ b/clusters/l3-sqnc/base/flux-system/gotk-sync.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: main
+    branch: chore/upgrade_production_services_with_attachment_api
   url: https://github.com/digicatapult/sqnc-flux-infra.git
 
 ---

--- a/clusters/l3-sqnc/base/flux-system/gotk-sync.yaml
+++ b/clusters/l3-sqnc/base/flux-system/gotk-sync.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: chore/upgrade_production_services_with_attachment_api
+    branch: main
   url: https://github.com/digicatapult/sqnc-flux-infra.git
 
 ---

--- a/clusters/l3-sqnc/capacity/attachment-api/kustomization.yaml
+++ b/clusters/l3-sqnc/capacity/attachment-api/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - release.yaml

--- a/clusters/l3-sqnc/capacity/attachment-api/release.yaml
+++ b/clusters/l3-sqnc/capacity/attachment-api/release.yaml
@@ -11,8 +11,6 @@ spec:
   upgrade:
     remediation:
       retries: -1
-  test:
-    enable: false
   dependsOn:
     - name: ipfs-capacity
     - name: capacity-identity-service

--- a/clusters/l3-sqnc/capacity/attachment-api/release.yaml
+++ b/clusters/l3-sqnc/capacity/attachment-api/release.yaml
@@ -2,7 +2,7 @@
 apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
-  name: capacity-matchmaker-api
+  name: capacity-attachment-api
   namespace: capacity
 spec:
   install:
@@ -18,27 +18,19 @@ spec:
     - name: capacity-identity-service
   chart:
     spec:
-      version: 4.0.2
-      chart: sqnc-matchmaker-api
+      chart: sqnc-attachment-api
       sourceRef:
         kind: HelmRepository
         name: digicatapult
+      version: 2.0.0
   valuesFrom:
     - kind: ConfigMap
       name: capacity-values
-      valuesKey: values-matchmaker-api.yaml
+      valuesKey: values-attachment-api.yaml
     - kind: Secret
-      name: capacity-matchmaker-postgres-creds
+      name: capacity-attachment-postgres-creds
       valuesKey: password
       targetPath: postgresql.auth.password
-    - kind: Secret
-      name: capacity-internal-client-secret
-      valuesKey: key
-      targetPath: auth.internalClientSecret
-    - kind: Secret
-      name: capacity-client-secret
-      valuesKey: key
-      targetPath: tests.auth.clientSecret
     - kind: Secret
       name: capacity-keys
       valuesKey: account_seed

--- a/clusters/l3-sqnc/capacity/attachment-api/release.yaml
+++ b/clusters/l3-sqnc/capacity/attachment-api/release.yaml
@@ -30,6 +30,10 @@ spec:
       valuesKey: password
       targetPath: postgresql.auth.password
     - kind: Secret
+      name: capacity-internal-client-secret
+      valuesKey: key
+      targetPath: auth.internalClientSecret
+    - kind: Secret
       name: capacity-keys
       valuesKey: account_seed
       targetPath: userUri

--- a/clusters/l3-sqnc/capacity/attachment-api/values.yaml
+++ b/clusters/l3-sqnc/capacity/attachment-api/values.yaml
@@ -15,6 +15,7 @@ auth:
   idpPathPrefix: /auth
   oauth2Realm: capacity
   internalRealm: capacity-internal
+  internalClientId: l3
 ingress:
   enabled: true
   ingressClassName: nginx-capacity

--- a/clusters/l3-sqnc/capacity/attachment-api/values.yaml
+++ b/clusters/l3-sqnc/capacity/attachment-api/values.yaml
@@ -1,27 +1,24 @@
-logLevel: trace
+logLevel: debug
 externalSqncNode:
   host: sqnc-node
   port: 9944
 externalSqncIpfs:
-  host: ipfs-order-sqnc-ipfs-api
+  host: ipfs-capacity-sqnc-ipfs-api
   port: 5001
 externalSqncIdentity:
-  host: order-identity-service-sqnc-identity-service
-  port: 3000
-externalSqncAttachment:
-  host: order-attachment-api
+  host: capacity-identity-service-sqnc-identity-service
   port: 3000
 auth:
   clientId: 'l3'
-  publicUrlPrefix: "https://auth.dsch-l3.com"
-  internalUrlPrefix: "http://keycloak.keycloak.svc.cluster.local"
+  publicIdpOrigin: "https://auth.dsch-l3.com"
+  internalIdpOrigin: "http://keycloak.keycloak.svc.cluster.local"
   idpPathPrefix: /auth
-  oauth2Realm: order
-  internalRealm: order-internal
+  oauth2Realm: capacity
+  internalRealm: capacity-internal
 ingress:
   enabled: true
-  ingressClassName: nginx-order
-  hostname: order.dsch-l3.com
+  ingressClassName: nginx-capacity
+  hostname: capacity.dsch-l3.com
 node:
   enabled: false
 postgresql:
@@ -36,18 +33,10 @@ postgresql:
     enabled: true
     serviceMonitor:
       enabled: true
-      namespace: order
+      namespace: capacity
       relabelings:
         - action: replace
           sourceLabels: [namespace]
           targetLabel: kubernetes_namespace
-image:
-  tag: "v3.0.81"
-global:
-  imagePullSecrets:
-    - name: dockerhub
 podAnnotations:
   instrumentation.opentelemetry.io/inject-nodejs: "monitoring/nodejs-instrumentation"
-tests:
-  auth:
-    clientId: l3

--- a/clusters/l3-sqnc/capacity/attachment-api/values.yaml
+++ b/clusters/l3-sqnc/capacity/attachment-api/values.yaml
@@ -12,7 +12,7 @@ auth:
   clientId: 'l3'
   publicIdpOrigin: "https://auth.dsch-l3.com"
   internalIdpOrigin: "http://keycloak.keycloak.svc.cluster.local"
-  idpPathPrefix: /auth
+  idpPathPrefix: ""
   oauth2Realm: capacity
   internalRealm: capacity-internal
   internalClientId: l3

--- a/clusters/l3-sqnc/capacity/identity-service/release.yaml
+++ b/clusters/l3-sqnc/capacity/identity-service/release.yaml
@@ -12,7 +12,7 @@ spec:
     - name: magenta
   chart:
     spec:
-      version: 4.0.1
+      version: 5.1.2
       chart: sqnc-identity-service
       sourceRef:
         kind: HelmRepository

--- a/clusters/l3-sqnc/capacity/identity-service/release.yaml
+++ b/clusters/l3-sqnc/capacity/identity-service/release.yaml
@@ -12,7 +12,7 @@ spec:
     - name: magenta
   chart:
     spec:
-      version: 5.1.2
+      version: 5.1.7
       chart: sqnc-identity-service
       sourceRef:
         kind: HelmRepository

--- a/clusters/l3-sqnc/capacity/identity-service/values.yaml
+++ b/clusters/l3-sqnc/capacity/identity-service/values.yaml
@@ -5,8 +5,8 @@ externalSqncNode:
   port: 9944
 auth:
   clientId: 'l3'
-  publicUrlPrefix: "https://auth.dsch-l3.com"
-  internalUrlPrefix: "http://keycloak.keycloak.svc.cluster.local"
+  publicIdpOrigin: "https://auth.dsch-l3.com"
+  internalIdpOrigin: "http://keycloak.keycloak.svc.cluster.local"
   idpPathPrefix: ""
   oauth2Realm: capacity
   internalRealm: capacity-internal

--- a/clusters/l3-sqnc/capacity/identity-service/values.yaml
+++ b/clusters/l3-sqnc/capacity/identity-service/values.yaml
@@ -5,8 +5,11 @@ externalSqncNode:
   port: 9944
 auth:
   clientId: 'l3'
-  publicUrlPrefix: "https://auth.dsch-l3.com/realms/capacity/protocol/openid-connect"
-  internalUrlPrefix: "http://keycloak.keycloak.svc.cluster.local/realms/capacity/protocol/openid-connect"
+  publicUrlPrefix: "https://auth.dsch-l3.com"
+  internalUrlPrefix: "http://keycloak.keycloak.svc.cluster.local"
+  idpPathPrefix: /auth
+  oauth2Realm: capacity
+  internalRealm: capacity-internal
 ingress:
   enabled: true
   ingressClassName: nginx-capacity

--- a/clusters/l3-sqnc/capacity/identity-service/values.yaml
+++ b/clusters/l3-sqnc/capacity/identity-service/values.yaml
@@ -7,7 +7,7 @@ auth:
   clientId: 'l3'
   publicUrlPrefix: "https://auth.dsch-l3.com"
   internalUrlPrefix: "http://keycloak.keycloak.svc.cluster.local"
-  idpPathPrefix: /auth
+  idpPathPrefix: ""
   oauth2Realm: capacity
   internalRealm: capacity-internal
 ingress:

--- a/clusters/l3-sqnc/capacity/kustomization.yaml
+++ b/clusters/l3-sqnc/capacity/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - ipfs-node
   - identity-service
   - matchmaker-api
+  - attachment-api
   - nginx
   - open-api-merger
   - source.yaml
@@ -20,6 +21,7 @@ configMapGenerator:
       - values-identity-service.yaml=identity-service/values.yaml
       - values-nginx.yaml=nginx/values.yaml
       - values-matchmaker-api.yaml=matchmaker-api/values.yaml
+      - values-attachment-api.yaml=attachment-api/values.yaml
       - values-open-api-merger.yaml=open-api-merger/values.yaml
 configurations:
   - kustomize-config.yaml

--- a/clusters/l3-sqnc/capacity/matchmaker-api/release.yaml
+++ b/clusters/l3-sqnc/capacity/matchmaker-api/release.yaml
@@ -18,7 +18,7 @@ spec:
     - name: capacity-identity-service
   chart:
     spec:
-      version: 4.0.2
+      version: 4.0.15
       chart: sqnc-matchmaker-api
       sourceRef:
         kind: HelmRepository

--- a/clusters/l3-sqnc/capacity/matchmaker-api/values.yaml
+++ b/clusters/l3-sqnc/capacity/matchmaker-api/values.yaml
@@ -9,7 +9,7 @@ externalSqncIdentity:
   host: capacity-identity-service-sqnc-identity-service
   port: 3000
 externalSqncAttachment:
-  host: capacity-attachment-api
+  host: capacity-matchmaker-api-sqnc-matchmaker-api
   port: 3000
 auth:
   clientId: 'l3'

--- a/clusters/l3-sqnc/capacity/matchmaker-api/values.yaml
+++ b/clusters/l3-sqnc/capacity/matchmaker-api/values.yaml
@@ -18,6 +18,7 @@ auth:
   idpPathPrefix: /auth
   oauth2Realm: capacity
   internalRealm: capacity-internal
+  internalClientId: l3
 ingress:
   enabled: true
   ingressClassName: nginx-capacity

--- a/clusters/l3-sqnc/capacity/matchmaker-api/values.yaml
+++ b/clusters/l3-sqnc/capacity/matchmaker-api/values.yaml
@@ -13,8 +13,8 @@ externalSqncAttachment:
   port: 3000
 auth:
   clientId: 'l3'
-  publicUrlPrefix: "https://auth.dsch-l3.com"
-  internalUrlPrefix: "http://keycloak.keycloak.svc.cluster.local"
+  publicIdpOrigin: "https://auth.dsch-l3.com"
+  internalIdpOrigin: "http://keycloak.keycloak.svc.cluster.local"
   idpPathPrefix: ""
   oauth2Realm: capacity
   internalRealm: capacity-internal

--- a/clusters/l3-sqnc/capacity/matchmaker-api/values.yaml
+++ b/clusters/l3-sqnc/capacity/matchmaker-api/values.yaml
@@ -9,7 +9,7 @@ externalSqncIdentity:
   host: capacity-identity-service-sqnc-identity-service
   port: 3000
 externalSqncAttachment:
-  host: capacity-matchmaker-api-sqnc-matchmaker-api
+  host: capacity-attachment-api-sqnc-attachment-api
   port: 3000
 auth:
   clientId: 'l3'

--- a/clusters/l3-sqnc/capacity/matchmaker-api/values.yaml
+++ b/clusters/l3-sqnc/capacity/matchmaker-api/values.yaml
@@ -8,10 +8,16 @@ externalSqncIpfs:
 externalSqncIdentity:
   host: capacity-identity-service-sqnc-identity-service
   port: 3000
+externalSqncAttachment:
+  host: capacity-attachment-api
+  port: 3000
 auth:
   clientId: 'l3'
-  publicUrlPrefix: "https://auth.dsch-l3.com/realms/capacity/protocol/openid-connect"
-  internalUrlPrefix: "http://keycloak.keycloak.svc.cluster.local/realms/capacity/protocol/openid-connect"
+  publicUrlPrefix: "https://auth.dsch-l3.com"
+  internalUrlPrefix: "http://keycloak.keycloak.svc.cluster.local"
+  idpPathPrefix: /auth
+  oauth2Realm: capacity
+  internalRealm: capacity-internal
 ingress:
   enabled: true
   ingressClassName: nginx-capacity
@@ -40,3 +46,6 @@ global:
     - name: dockerhub
 podAnnotations:
   instrumentation.opentelemetry.io/inject-nodejs: "monitoring/nodejs-instrumentation"
+tests:
+  auth:
+    clientId: l3

--- a/clusters/l3-sqnc/capacity/matchmaker-api/values.yaml
+++ b/clusters/l3-sqnc/capacity/matchmaker-api/values.yaml
@@ -15,7 +15,7 @@ auth:
   clientId: 'l3'
   publicUrlPrefix: "https://auth.dsch-l3.com"
   internalUrlPrefix: "http://keycloak.keycloak.svc.cluster.local"
-  idpPathPrefix: /auth
+  idpPathPrefix: ""
   oauth2Realm: capacity
   internalRealm: capacity-internal
   internalClientId: l3

--- a/clusters/l3-sqnc/capacity/open-api-merger/values.yaml
+++ b/clusters/l3-sqnc/capacity/open-api-merger/values.yaml
@@ -2,7 +2,7 @@ logLevel: info
 paths:
   - http://capacity-identity-service-sqnc-identity-service:3000/api-docs
   - http://capacity-matchmaker-api-sqnc-matchmaker-api:3000/api-docs
-  - http://capacity-attachment-api:3000/api-docs
+  - http://capacity-attachment-api-sqnc-attachment-api:3000/api-docs
 baseUrl:
   - https://capacity.dsch-l3.com
 securitySchema:

--- a/clusters/l3-sqnc/capacity/open-api-merger/values.yaml
+++ b/clusters/l3-sqnc/capacity/open-api-merger/values.yaml
@@ -14,7 +14,21 @@ securitySchema:
       - clientCredentials
     tokenUrl: "https://auth.dsch-l3.com/realms/capacity/protocol/openid-connect/token"
     refreshUrl: "https://auth.dsch-l3.com/realms/capacity/protocol/openid-connect/token"
-    scopes: {}
+    scopes:
+      demandA:read: "Read demandA"
+      demandA:prepare: "Prepare demandA"
+      demandA:create: "Create demandA"
+      demandA:comment: "Comment on demandA"
+      demandB:read: "Read demandB"
+      demandB:prepare: "Prepare demandB"
+      demandB:create: "Create demandB"
+      demandB:comment: "Comment on demandB"
+      match2:read: "Read match2"
+      match2:prepare: "Prepare match2"
+      match2:propose: "Propose match2"
+      match2:cancel: "Cancel match2"
+      match2:accept: "Accept match2"
+      match2:reject: "Reject match2"
 ingress:
   ingressClassName: nginx-capacity
   enabled: true

--- a/clusters/l3-sqnc/capacity/open-api-merger/values.yaml
+++ b/clusters/l3-sqnc/capacity/open-api-merger/values.yaml
@@ -2,6 +2,7 @@ logLevel: info
 paths:
   - http://capacity-identity-service-sqnc-identity-service:3000/api-docs
   - http://capacity-matchmaker-api-sqnc-matchmaker-api:3000/api-docs
+  - http://capacity-attachment-api:3000/api-docs
 baseUrl:
   - https://capacity.dsch-l3.com
 securitySchema:

--- a/clusters/l3-sqnc/optimiser/attachment-api/kustomization.yaml
+++ b/clusters/l3-sqnc/optimiser/attachment-api/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - release.yaml

--- a/clusters/l3-sqnc/optimiser/attachment-api/release.yaml
+++ b/clusters/l3-sqnc/optimiser/attachment-api/release.yaml
@@ -30,6 +30,10 @@ spec:
       valuesKey: password
       targetPath: postgresql.auth.password
     - kind: Secret
+      name: optimiser-internal-client-secret
+      valuesKey: key
+      targetPath: auth.internalClientSecret
+    - kind: Secret
       name: optimiser-keys
       valuesKey: account_seed
       targetPath: userUri

--- a/clusters/l3-sqnc/optimiser/attachment-api/release.yaml
+++ b/clusters/l3-sqnc/optimiser/attachment-api/release.yaml
@@ -2,7 +2,7 @@
 apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
-  name: optimiser-matchmaker-api
+  name: optimiser-attachment-api
   namespace: optimiser
 spec:
   install:
@@ -18,27 +18,19 @@ spec:
     - name: optimiser-identity-service
   chart:
     spec:
-      version: 4.0.2
-      chart: sqnc-matchmaker-api
+      chart: sqnc-attachment-api
       sourceRef:
         kind: HelmRepository
         name: digicatapult
+      version: 2.0.0
   valuesFrom:
     - kind: ConfigMap
       name: optimiser-values
-      valuesKey: values-matchmaker-api.yaml
+      valuesKey: values-attachment-api.yaml
     - kind: Secret
-      name: optimiser-matchmaker-postgres-creds
+      name: optimiser-attachment-postgres-creds
       valuesKey: password
       targetPath: postgresql.auth.password
-    - kind: Secret
-      name: optimiser-internal-client-secret
-      valuesKey: key
-      targetPath: auth.internalClientSecret
-    - kind: Secret
-      name: optimiser-client-secret
-      valuesKey: key
-      targetPath: tests.auth.clientSecret
     - kind: Secret
       name: optimiser-keys
       valuesKey: account_seed

--- a/clusters/l3-sqnc/optimiser/attachment-api/release.yaml
+++ b/clusters/l3-sqnc/optimiser/attachment-api/release.yaml
@@ -11,8 +11,6 @@ spec:
   upgrade:
     remediation:
       retries: -1
-  test:
-    enable: false
   dependsOn:
     - name: ipfs-optimiser
     - name: optimiser-identity-service

--- a/clusters/l3-sqnc/optimiser/attachment-api/values.yaml
+++ b/clusters/l3-sqnc/optimiser/attachment-api/values.yaml
@@ -12,7 +12,7 @@ auth:
   clientId: 'l3'
   publicIdpOrigin: "https://auth.dsch-l3.com"
   internalIdpOrigin: "http://keycloak.keycloak.svc.cluster.local"
-  idpPathPrefix: /auth
+  idpPathPrefix: ""
   oauth2Realm: optimiser
   internalRealm: optimiser-internal
   internalClientId: l3

--- a/clusters/l3-sqnc/optimiser/attachment-api/values.yaml
+++ b/clusters/l3-sqnc/optimiser/attachment-api/values.yaml
@@ -1,27 +1,24 @@
-logLevel: trace
+logLevel: debug
 externalSqncNode:
   host: sqnc-node
   port: 9944
 externalSqncIpfs:
-  host: ipfs-order-sqnc-ipfs-api
+  host: ipfs-optimiser-sqnc-ipfs-api
   port: 5001
 externalSqncIdentity:
-  host: order-identity-service-sqnc-identity-service
-  port: 3000
-externalSqncAttachment:
-  host: order-attachment-api
+  host: optimiser-identity-service-sqnc-identity-service
   port: 3000
 auth:
   clientId: 'l3'
-  publicUrlPrefix: "https://auth.dsch-l3.com"
-  internalUrlPrefix: "http://keycloak.keycloak.svc.cluster.local"
+  publicIdpOrigin: "https://auth.dsch-l3.com"
+  internalIdpOrigin: "http://keycloak.keycloak.svc.cluster.local"
   idpPathPrefix: /auth
-  oauth2Realm: order
-  internalRealm: order-internal
+  oauth2Realm: optimiser
+  internalRealm: optimiser-internal
 ingress:
   enabled: true
-  ingressClassName: nginx-order
-  hostname: order.dsch-l3.com
+  ingressClassName: nginx-optimiser
+  hostname: optimiser.dsch-l3.com
 node:
   enabled: false
 postgresql:
@@ -36,18 +33,10 @@ postgresql:
     enabled: true
     serviceMonitor:
       enabled: true
-      namespace: order
+      namespace: optimiser
       relabelings:
         - action: replace
           sourceLabels: [namespace]
           targetLabel: kubernetes_namespace
-image:
-  tag: "v3.0.81"
-global:
-  imagePullSecrets:
-    - name: dockerhub
 podAnnotations:
   instrumentation.opentelemetry.io/inject-nodejs: "monitoring/nodejs-instrumentation"
-tests:
-  auth:
-    clientId: l3

--- a/clusters/l3-sqnc/optimiser/attachment-api/values.yaml
+++ b/clusters/l3-sqnc/optimiser/attachment-api/values.yaml
@@ -15,6 +15,7 @@ auth:
   idpPathPrefix: /auth
   oauth2Realm: optimiser
   internalRealm: optimiser-internal
+  internalClientId: l3
 ingress:
   enabled: true
   ingressClassName: nginx-optimiser

--- a/clusters/l3-sqnc/optimiser/identity-service/release.yaml
+++ b/clusters/l3-sqnc/optimiser/identity-service/release.yaml
@@ -12,7 +12,7 @@ spec:
     - name: yellow-node
   chart:
     spec:
-      version: 5.1.2
+      version: 5.1.7
       chart: sqnc-identity-service
       sourceRef:
         kind: HelmRepository

--- a/clusters/l3-sqnc/optimiser/identity-service/release.yaml
+++ b/clusters/l3-sqnc/optimiser/identity-service/release.yaml
@@ -12,7 +12,7 @@ spec:
     - name: yellow-node
   chart:
     spec:
-      version: 4.0.1
+      version: 5.1.2
       chart: sqnc-identity-service
       sourceRef:
         kind: HelmRepository

--- a/clusters/l3-sqnc/optimiser/identity-service/values.yaml
+++ b/clusters/l3-sqnc/optimiser/identity-service/values.yaml
@@ -7,7 +7,7 @@ auth:
   clientId: 'l3'
   publicUrlPrefix: "https://auth.dsch-l3.com"
   internalUrlPrefix: "http://keycloak.keycloak.svc.cluster.local"
-  idpPathPrefix: /auth
+  idpPathPrefix: ""
   oauth2Realm: optimiser
   internalRealm: optimiser-internal
 ingress:

--- a/clusters/l3-sqnc/optimiser/identity-service/values.yaml
+++ b/clusters/l3-sqnc/optimiser/identity-service/values.yaml
@@ -5,8 +5,8 @@ externalSqncNode:
   port: 9944
 auth:
   clientId: 'l3'
-  publicUrlPrefix: "https://auth.dsch-l3.com"
-  internalUrlPrefix: "http://keycloak.keycloak.svc.cluster.local"
+  publicIdpOrigin: "https://auth.dsch-l3.com"
+  internalIdpOrigin: "http://keycloak.keycloak.svc.cluster.local"
   idpPathPrefix: ""
   oauth2Realm: optimiser
   internalRealm: optimiser-internal

--- a/clusters/l3-sqnc/optimiser/identity-service/values.yaml
+++ b/clusters/l3-sqnc/optimiser/identity-service/values.yaml
@@ -5,8 +5,11 @@ externalSqncNode:
   port: 9944
 auth:
   clientId: 'l3'
-  publicUrlPrefix: "https://auth.dsch-l3.com/realms/optimiser/protocol/openid-connect"
-  internalUrlPrefix: "http://keycloak.keycloak.svc.cluster.local/realms/optimiser/protocol/openid-connect"
+  publicUrlPrefix: "https://auth.dsch-l3.com"
+  internalUrlPrefix: "http://keycloak.keycloak.svc.cluster.local"
+  idpPathPrefix: /auth
+  oauth2Realm: optimiser
+  internalRealm: optimiser-internal
 ingress:
   enabled: true
   ingressClassName: nginx-optimiser

--- a/clusters/l3-sqnc/optimiser/kustomization.yaml
+++ b/clusters/l3-sqnc/optimiser/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - yellow-node
   - identity-service
   - matchmaker-api
+  - attachment-api
   - ipfs-node
   - nginx
   - open-api-merger
@@ -20,6 +21,7 @@ configMapGenerator:
       - values-identity-service.yaml=identity-service/values.yaml
       - values-nginx.yaml=nginx/values.yaml
       - values-matchmaker-api.yaml=matchmaker-api/values.yaml
+      - values-attachment-api.yaml=attachment-api/values.yaml
       - values-open-api-merger.yaml=open-api-merger/values.yaml
 configurations:
   - kustomize-config.yaml

--- a/clusters/l3-sqnc/optimiser/matchmaker-api/release.yaml
+++ b/clusters/l3-sqnc/optimiser/matchmaker-api/release.yaml
@@ -18,7 +18,7 @@ spec:
     - name: optimiser-identity-service
   chart:
     spec:
-      version: 4.0.2
+      version: 4.0.15
       chart: sqnc-matchmaker-api
       sourceRef:
         kind: HelmRepository

--- a/clusters/l3-sqnc/optimiser/matchmaker-api/values.yaml
+++ b/clusters/l3-sqnc/optimiser/matchmaker-api/values.yaml
@@ -18,6 +18,7 @@ auth:
   idpPathPrefix: /auth
   oauth2Realm: optimiser
   internalRealm: optimiser-internal
+  internalClientId: l3
 ingress:
   enabled: true
   ingressClassName: nginx-optimiser

--- a/clusters/l3-sqnc/optimiser/matchmaker-api/values.yaml
+++ b/clusters/l3-sqnc/optimiser/matchmaker-api/values.yaml
@@ -8,10 +8,16 @@ externalSqncIpfs:
 externalSqncIdentity:
   host: optimiser-identity-service-sqnc-identity-service
   port: 3000
+externalSqncAttachment:
+  host: optimiser-attachment-api
+  port: 3000
 auth:
   clientId: 'l3'
-  publicUrlPrefix: "https://auth.dsch-l3.com/realms/optimiser/protocol/openid-connect"
-  internalUrlPrefix: "http://keycloak.keycloak.svc.cluster.local/realms/optimiser/protocol/openid-connect"
+  publicUrlPrefix: "https://auth.dsch-l3.com"
+  internalUrlPrefix: "http://keycloak.keycloak.svc.cluster.local"
+  idpPathPrefix: /auth
+  oauth2Realm: optimiser
+  internalRealm: optimiser-internal
 ingress:
   enabled: true
   ingressClassName: nginx-optimiser
@@ -40,3 +46,6 @@ global:
     - name: dockerhub
 podAnnotations:
   instrumentation.opentelemetry.io/inject-nodejs: "monitoring/nodejs-instrumentation"
+tests:
+  auth:
+    clientId: l3

--- a/clusters/l3-sqnc/optimiser/matchmaker-api/values.yaml
+++ b/clusters/l3-sqnc/optimiser/matchmaker-api/values.yaml
@@ -9,7 +9,7 @@ externalSqncIdentity:
   host: optimiser-identity-service-sqnc-identity-service
   port: 3000
 externalSqncAttachment:
-  host: optimiser-attachment-api
+  host: optimiser-attachment-api-sqnc-attachment-api
   port: 3000
 auth:
   clientId: 'l3'

--- a/clusters/l3-sqnc/optimiser/matchmaker-api/values.yaml
+++ b/clusters/l3-sqnc/optimiser/matchmaker-api/values.yaml
@@ -13,8 +13,8 @@ externalSqncAttachment:
   port: 3000
 auth:
   clientId: 'l3'
-  publicUrlPrefix: "https://auth.dsch-l3.com"
-  internalUrlPrefix: "http://keycloak.keycloak.svc.cluster.local"
+  publicIdpOrigin: "https://auth.dsch-l3.com"
+  internalIdpOrigin: "http://keycloak.keycloak.svc.cluster.local"
   idpPathPrefix: ""
   oauth2Realm: optimiser
   internalRealm: optimiser-internal

--- a/clusters/l3-sqnc/optimiser/matchmaker-api/values.yaml
+++ b/clusters/l3-sqnc/optimiser/matchmaker-api/values.yaml
@@ -15,7 +15,7 @@ auth:
   clientId: 'l3'
   publicUrlPrefix: "https://auth.dsch-l3.com"
   internalUrlPrefix: "http://keycloak.keycloak.svc.cluster.local"
-  idpPathPrefix: /auth
+  idpPathPrefix: ""
   oauth2Realm: optimiser
   internalRealm: optimiser-internal
   internalClientId: l3

--- a/clusters/l3-sqnc/optimiser/open-api-merger/values.yaml
+++ b/clusters/l3-sqnc/optimiser/open-api-merger/values.yaml
@@ -2,6 +2,7 @@ logLevel: info
 paths:
   - http://optimiser-identity-service-sqnc-identity-service:3000/api-docs
   - http://optimiser-matchmaker-api-sqnc-matchmaker-api:3000/api-docs
+  - http://optimiser-attachment-api:3000/api-docs
 baseUrl:
   - https://optimiser.dsch-l3.com
 securitySchema:

--- a/clusters/l3-sqnc/optimiser/open-api-merger/values.yaml
+++ b/clusters/l3-sqnc/optimiser/open-api-merger/values.yaml
@@ -2,7 +2,7 @@ logLevel: info
 paths:
   - http://optimiser-identity-service-sqnc-identity-service:3000/api-docs
   - http://optimiser-matchmaker-api-sqnc-matchmaker-api:3000/api-docs
-  - http://optimiser-attachment-api:3000/api-docs
+  - http://optimiser-attachment-api-sqnc-attachment-api:3000/api-docs
 baseUrl:
   - https://optimiser.dsch-l3.com
 securitySchema:

--- a/clusters/l3-sqnc/optimiser/open-api-merger/values.yaml
+++ b/clusters/l3-sqnc/optimiser/open-api-merger/values.yaml
@@ -14,7 +14,21 @@ securitySchema:
       - clientCredentials
     tokenUrl: "https://auth.dsch-l3.com/realms/optimiser/protocol/openid-connect/token"
     refreshUrl: "https://auth.dsch-l3.com/realms/optimiser/protocol/openid-connect/token"
-    scopes: {}
+    scopes:
+      demandA:read: "Read demandA"
+      demandA:prepare: "Prepare demandA"
+      demandA:create: "Create demandA"
+      demandA:comment: "Comment on demandA"
+      demandB:read: "Read demandB"
+      demandB:prepare: "Prepare demandB"
+      demandB:create: "Create demandB"
+      demandB:comment: "Comment on demandB"
+      match2:read: "Read match2"
+      match2:prepare: "Prepare match2"
+      match2:propose: "Propose match2"
+      match2:cancel: "Cancel match2"
+      match2:accept: "Accept match2"
+      match2:reject: "Reject match2"
 ingress:
   ingressClassName: nginx-optimiser
   enabled: true

--- a/clusters/l3-sqnc/order/attachment-api/kustomization.yaml
+++ b/clusters/l3-sqnc/order/attachment-api/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - release.yaml

--- a/clusters/l3-sqnc/order/attachment-api/release.yaml
+++ b/clusters/l3-sqnc/order/attachment-api/release.yaml
@@ -30,6 +30,10 @@ spec:
       valuesKey: password
       targetPath: postgresql.auth.password
     - kind: Secret
+      name: order-internal-client-secret
+      valuesKey: key
+      targetPath: auth.internalClientSecret
+    - kind: Secret
       name: order-keys
       valuesKey: account_seed
       targetPath: userUri

--- a/clusters/l3-sqnc/order/attachment-api/release.yaml
+++ b/clusters/l3-sqnc/order/attachment-api/release.yaml
@@ -2,7 +2,7 @@
 apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
-  name: order-matchmaker-api
+  name: order-attachment-api
   namespace: order
 spec:
   install:
@@ -18,27 +18,19 @@ spec:
     - name: order-identity-service
   chart:
     spec:
-      version: 4.0.2
-      chart: sqnc-matchmaker-api
+      chart: sqnc-attachment-api
       sourceRef:
         kind: HelmRepository
         name: digicatapult
+      version: 2.0.0
   valuesFrom:
     - kind: ConfigMap
       name: order-values
-      valuesKey: values-matchmaker-api.yaml
+      valuesKey: values-attachment-api.yaml
     - kind: Secret
-      name: order-matchmaker-postgres-creds
+      name: order-attachment-postgres-creds
       valuesKey: password
       targetPath: postgresql.auth.password
-    - kind: Secret
-      name: order-internal-client-secret
-      valuesKey: key
-      targetPath: auth.internalClientSecret
-    - kind: Secret
-      name: order-client-secret
-      valuesKey: key
-      targetPath: tests.auth.clientSecret
     - kind: Secret
       name: order-keys
       valuesKey: account_seed

--- a/clusters/l3-sqnc/order/attachment-api/release.yaml
+++ b/clusters/l3-sqnc/order/attachment-api/release.yaml
@@ -11,8 +11,6 @@ spec:
   upgrade:
     remediation:
       retries: -1
-  test:
-    enable: false
   dependsOn:
     - name: ipfs-order
     - name: order-identity-service

--- a/clusters/l3-sqnc/order/attachment-api/values.yaml
+++ b/clusters/l3-sqnc/order/attachment-api/values.yaml
@@ -1,4 +1,4 @@
-logLevel: trace
+logLevel: debug
 externalSqncNode:
   host: sqnc-node
   port: 9944
@@ -8,13 +8,10 @@ externalSqncIpfs:
 externalSqncIdentity:
   host: order-identity-service-sqnc-identity-service
   port: 3000
-externalSqncAttachment:
-  host: order-attachment-api
-  port: 3000
 auth:
   clientId: 'l3'
-  publicUrlPrefix: "https://auth.dsch-l3.com"
-  internalUrlPrefix: "http://keycloak.keycloak.svc.cluster.local"
+  publicIdpOrigin: "https://auth.dsch-l3.com"
+  internalIdpOrigin: "http://keycloak.keycloak.svc.cluster.local"
   idpPathPrefix: /auth
   oauth2Realm: order
   internalRealm: order-internal
@@ -41,13 +38,5 @@ postgresql:
         - action: replace
           sourceLabels: [namespace]
           targetLabel: kubernetes_namespace
-image:
-  tag: "v3.0.81"
-global:
-  imagePullSecrets:
-    - name: dockerhub
 podAnnotations:
   instrumentation.opentelemetry.io/inject-nodejs: "monitoring/nodejs-instrumentation"
-tests:
-  auth:
-    clientId: l3

--- a/clusters/l3-sqnc/order/attachment-api/values.yaml
+++ b/clusters/l3-sqnc/order/attachment-api/values.yaml
@@ -15,6 +15,7 @@ auth:
   idpPathPrefix: /auth
   oauth2Realm: order
   internalRealm: order-internal
+  internalClientId: l3
 ingress:
   enabled: true
   ingressClassName: nginx-order

--- a/clusters/l3-sqnc/order/attachment-api/values.yaml
+++ b/clusters/l3-sqnc/order/attachment-api/values.yaml
@@ -12,7 +12,7 @@ auth:
   clientId: 'l3'
   publicIdpOrigin: "https://auth.dsch-l3.com"
   internalIdpOrigin: "http://keycloak.keycloak.svc.cluster.local"
-  idpPathPrefix: /auth
+  idpPathPrefix: ""
   oauth2Realm: order
   internalRealm: order-internal
   internalClientId: l3

--- a/clusters/l3-sqnc/order/identity-service/release.yaml
+++ b/clusters/l3-sqnc/order/identity-service/release.yaml
@@ -12,7 +12,7 @@ spec:
     - name: blue-node
   chart:
     spec:
-      version: 5.1.2
+      version: 5.1.7
       chart: sqnc-identity-service
       sourceRef:
         kind: HelmRepository

--- a/clusters/l3-sqnc/order/identity-service/release.yaml
+++ b/clusters/l3-sqnc/order/identity-service/release.yaml
@@ -12,7 +12,7 @@ spec:
     - name: blue-node
   chart:
     spec:
-      version: 4.0.1
+      version: 5.1.2
       chart: sqnc-identity-service
       sourceRef:
         kind: HelmRepository

--- a/clusters/l3-sqnc/order/identity-service/values.yaml
+++ b/clusters/l3-sqnc/order/identity-service/values.yaml
@@ -5,8 +5,11 @@ externalSqncNode:
   port: 9944
 auth:
   clientId: 'l3'
-  publicUrlPrefix: "https://auth.dsch-l3.com/realms/order/protocol/openid-connect"
-  internalUrlPrefix: "http://keycloak.keycloak.svc.cluster.local/realms/order/protocol/openid-connect"
+  publicUrlPrefix: "https://auth.dsch-l3.com"
+  internalUrlPrefix: "http://keycloak.keycloak.svc.cluster.local"
+  idpPathPrefix: /auth
+  oauth2Realm: order
+  internalRealm: order-internal
 ingress:
   enabled: true
   ingressClassName: nginx-order

--- a/clusters/l3-sqnc/order/identity-service/values.yaml
+++ b/clusters/l3-sqnc/order/identity-service/values.yaml
@@ -5,8 +5,8 @@ externalSqncNode:
   port: 9944
 auth:
   clientId: 'l3'
-  publicUrlPrefix: "https://auth.dsch-l3.com"
-  internalUrlPrefix: "http://keycloak.keycloak.svc.cluster.local"
+  publicIdpOrigin: "https://auth.dsch-l3.com"
+  internalIdpOrigin: "http://keycloak.keycloak.svc.cluster.local"
   idpPathPrefix: ""
   oauth2Realm: order
   internalRealm: order-internal

--- a/clusters/l3-sqnc/order/identity-service/values.yaml
+++ b/clusters/l3-sqnc/order/identity-service/values.yaml
@@ -7,7 +7,7 @@ auth:
   clientId: 'l3'
   publicUrlPrefix: "https://auth.dsch-l3.com"
   internalUrlPrefix: "http://keycloak.keycloak.svc.cluster.local"
-  idpPathPrefix: /auth
+  idpPathPrefix: ""
   oauth2Realm: order
   internalRealm: order-internal
 ingress:

--- a/clusters/l3-sqnc/order/kustomization.yaml
+++ b/clusters/l3-sqnc/order/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - cyan-node
   - identity-service
   - matchmaker-api
+  - attachment-api
   - ipfs-node
   - nginx
   - open-api-merger
@@ -20,6 +21,7 @@ configMapGenerator:
       - values-identity-service.yaml=identity-service/values.yaml
       - values-nginx.yaml=nginx/values.yaml
       - values-matchmaker-api.yaml=matchmaker-api/values.yaml
+      - values-attachment-api.yaml=attachment-api/values.yaml
       - values-open-api-merger.yaml=open-api-merger/values.yaml
 configurations:
   - kustomize-config.yaml

--- a/clusters/l3-sqnc/order/matchmaker-api/release.yaml
+++ b/clusters/l3-sqnc/order/matchmaker-api/release.yaml
@@ -18,7 +18,7 @@ spec:
     - name: order-identity-service
   chart:
     spec:
-      version: 4.0.2
+      version: 4.0.15
       chart: sqnc-matchmaker-api
       sourceRef:
         kind: HelmRepository

--- a/clusters/l3-sqnc/order/matchmaker-api/values.yaml
+++ b/clusters/l3-sqnc/order/matchmaker-api/values.yaml
@@ -13,8 +13,8 @@ externalSqncAttachment:
   port: 3000
 auth:
   clientId: 'l3'
-  publicUrlPrefix: "https://auth.dsch-l3.com"
-  internalUrlPrefix: "http://keycloak.keycloak.svc.cluster.local"
+  publicIdpOrigin: "https://auth.dsch-l3.com"
+  internalIdpOrigin: "http://keycloak.keycloak.svc.cluster.local"
   idpPathPrefix: ""
   oauth2Realm: order
   internalRealm: order-internal

--- a/clusters/l3-sqnc/order/matchmaker-api/values.yaml
+++ b/clusters/l3-sqnc/order/matchmaker-api/values.yaml
@@ -9,7 +9,7 @@ externalSqncIdentity:
   host: order-identity-service-sqnc-identity-service
   port: 3000
 externalSqncAttachment:
-  host: order-attachment-api
+  host: order-attachment-api-sqnc-attachment-api
   port: 3000
 auth:
   clientId: 'l3'

--- a/clusters/l3-sqnc/order/matchmaker-api/values.yaml
+++ b/clusters/l3-sqnc/order/matchmaker-api/values.yaml
@@ -18,6 +18,7 @@ auth:
   idpPathPrefix: /auth
   oauth2Realm: order
   internalRealm: order-internal
+  internalClientId: l3
 ingress:
   enabled: true
   ingressClassName: nginx-order

--- a/clusters/l3-sqnc/order/matchmaker-api/values.yaml
+++ b/clusters/l3-sqnc/order/matchmaker-api/values.yaml
@@ -15,7 +15,7 @@ auth:
   clientId: 'l3'
   publicUrlPrefix: "https://auth.dsch-l3.com"
   internalUrlPrefix: "http://keycloak.keycloak.svc.cluster.local"
-  idpPathPrefix: /auth
+  idpPathPrefix: ""
   oauth2Realm: order
   internalRealm: order-internal
   internalClientId: l3

--- a/clusters/l3-sqnc/order/matchmaker-api/values.yaml
+++ b/clusters/l3-sqnc/order/matchmaker-api/values.yaml
@@ -42,8 +42,6 @@ postgresql:
         - action: replace
           sourceLabels: [namespace]
           targetLabel: kubernetes_namespace
-image:
-  tag: "v3.0.81"
 global:
   imagePullSecrets:
     - name: dockerhub

--- a/clusters/l3-sqnc/order/open-api-merger/values.yaml
+++ b/clusters/l3-sqnc/order/open-api-merger/values.yaml
@@ -2,7 +2,7 @@ logLevel: info
 paths:
   - http://order-identity-service-sqnc-identity-service:3000/api-docs
   - http://order-matchmaker-api-sqnc-matchmaker-api:3000/api-docs
-  - http://order-attachment-api:3000/api-docs
+  - http://order-attachment-api-sqnc-attachment-api:3000/api-docs
 baseUrl:
   - https://order.dsch-l3.com
 securitySchema:

--- a/clusters/l3-sqnc/order/open-api-merger/values.yaml
+++ b/clusters/l3-sqnc/order/open-api-merger/values.yaml
@@ -14,7 +14,21 @@ securitySchema:
       - clientCredentials
     tokenUrl: "https://auth.dsch-l3.com/realms/order/protocol/openid-connect/token"
     refreshUrl: "https://auth.dsch-l3.com/realms/order/protocol/openid-connect/token"
-    scopes: {}
+    scopes:
+      demandA:read: "Read demandA"
+      demandA:prepare: "Prepare demandA"
+      demandA:create: "Create demandA"
+      demandA:comment: "Comment on demandA"
+      demandB:read: "Read demandB"
+      demandB:prepare: "Prepare demandB"
+      demandB:create: "Create demandB"
+      demandB:comment: "Comment on demandB"
+      match2:read: "Read match2"
+      match2:prepare: "Prepare match2"
+      match2:propose: "Propose match2"
+      match2:cancel: "Cancel match2"
+      match2:accept: "Accept match2"
+      match2:reject: "Reject match2"
 ingress:
   ingressClassName: nginx-order
   enabled: true

--- a/clusters/l3-sqnc/order/open-api-merger/values.yaml
+++ b/clusters/l3-sqnc/order/open-api-merger/values.yaml
@@ -2,6 +2,7 @@ logLevel: info
 paths:
   - http://order-identity-service-sqnc-identity-service:3000/api-docs
   - http://order-matchmaker-api-sqnc-matchmaker-api:3000/api-docs
+  - http://order-attachment-api:3000/api-docs
 baseUrl:
   - https://order.dsch-l3.com
 securitySchema:

--- a/clusters/l3-sqnc/secrets/capacity-attachment-postgres-creds.yaml
+++ b/clusters/l3-sqnc/secrets/capacity-attachment-postgres-creds.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+data:
+    password: ENC[AES256_GCM,data:RNGIa6A50IECmIK3nN2rZYbwvut57hq31qiWP40YyWwyyupkf3pgv3WhI6hL8vwl,iv:D+EDjty/d3LRtv3Lbr15C+EZhTWL30qxakRt2w1J878=,tag:onmJeM4lh6d2KE9zvA9IRQ==,type:str]
+kind: Secret
+metadata:
+    creationTimestamp: null
+    name: capacity-attachment-postgres-creds
+    namespace: capacity
+sops:
+    lastmodified: "2025-04-11T14:30:57Z"
+    mac: ENC[AES256_GCM,data:5OhDxVkNbwG5B4QXoD2J/Hqs1uNYjyGurKKl+ZOQ2WRmuLQRv4TAFaNOkVQ0hLWIPgGSDcu0ZeIigCuAzSQ9busn3JfjMt9p9XJUj4iQADwQPl73hKCxcFZYEt5CHVqVHiEOLK+XMwxF4DtdM+OQSVUv4mk3vhVgYRTycB5LdgU=,iv:eTQaVKrM77MDYOT9eVpjjd2xOfB+NquPHxsUAni48C8=,tag:WYDr/M+Fr7V1L3sVotHaCA==,type:str]
+    pgp:
+        - created_at: "2025-04-11T14:30:57Z"
+          enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            hF4DWK9rONmXZEsSAQdAxjDwe2s1Qh6jQQpFjom474W4Zz/OxzGzxMxw4DUG8EQw
+            ABxVhVYjRgIkyMf2U0JS9e0pAQbAAe3qmlV02I3f7vlDi1na718CWj6HWy20aHNY
+            1GgBCQIQEJ2YUrtkheyDEHYh9o3t/yEgtpXMChIjb7Fmirv49SOJC2GUxAkVuFpR
+            OnP416bQyvLRO2abLCLMxHfM7PpU1pAHLqICiHFxI+EiZ7z6NSmwY7qdRgVos/TV
+            eVWB5uMtoKroiA==
+            =Md4R
+            -----END PGP MESSAGE-----
+          fp: BC3A767578FF432C7414DE6A73A07B99E207F7AF
+    encrypted_regex: ^(data|stringData)$
+    version: 3.10.1

--- a/clusters/l3-sqnc/secrets/capacity-client-secret.yaml
+++ b/clusters/l3-sqnc/secrets/capacity-client-secret.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+data:
+    key: ENC[AES256_GCM,data:pABw2xhLeamG6UUmU4jt+VE8wF5vFy/rlEZKmldRUIhwiDSo7uMajqD+mRY=,iv:CDCopIeUHkxeNo2aSTkp4xrSHfBfGXBH4O8CJ/9wnfE=,tag:w9S5aTrNBU5SZqpgkJ2WfA==,type:str]
+kind: Secret
+metadata:
+    creationTimestamp: null
+    name: capacity-client-secret
+    namespace: capacity
+sops:
+    lastmodified: "2025-04-11T14:30:57Z"
+    mac: ENC[AES256_GCM,data:SXNDH8WJlM9QDlVEx8e0kmSDG12T0+jt2TuS0V3ExBwRtSGtN0tauxq+PzKV+S8Abd8pC2pYro4A/xvapGfDDaG8cRkJDs3sjEy9dZb/Ory2xLMbseVbEQcU+AVXvwO8cy/teIH/FaWKobAds1j2+OsRVYBEGWM47W7FY4Zerso=,iv:ryaUXnwCc9O0wwsCWoZIVA/e3trHXHGIeKmu3w8NhoQ=,tag:s5zTBvcZX+KENiKpGmaxJw==,type:str]
+    pgp:
+        - created_at: "2025-04-11T14:30:57Z"
+          enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            hF4DWK9rONmXZEsSAQdALYeX3v5WR/C2T+F6F+n3nDz1Xr5PLIHAuKy4Satq7zMw
+            1a7ZO0ie41YcOyNE4uHVkUunn0j+6vckw0qt7aJnB5Tkf1Ye2uo8RS5jYgGCDfQi
+            1GgBCQIQsKZ15l+UTpgbwGeoih8TO7f+A8sKnDxmdXYrf/8UXGarsFBdI+7IMWpt
+            JHJj6EdHMKQeqDplvfipD229UUsElF14zFOfJUvh/IgsXnuekXzrOlh6PCvVFIhs
+            Q0c+SI+nAR5RiQ==
+            =c0+h
+            -----END PGP MESSAGE-----
+          fp: BC3A767578FF432C7414DE6A73A07B99E207F7AF
+    encrypted_regex: ^(data|stringData)$
+    version: 3.10.1

--- a/clusters/l3-sqnc/secrets/capacity-internal-client-secret.yaml
+++ b/clusters/l3-sqnc/secrets/capacity-internal-client-secret.yaml
@@ -1,26 +1,26 @@
 apiVersion: v1
 data:
-    key: ENC[AES256_GCM,data:kezqr/Tfd3RkO9lvcElksGfAJAJHqZSQF2a1/jE4xM6Rk4xJxeYb3gb8Nv8=,iv:Q+vp0CajZLXTLTzjKTJkFvMYEEHdBuLagTlIMjgNeYA=,tag:P2RRywcO2k/p66pkNufMNQ==,type:str]
+    key: ENC[AES256_GCM,data:UcgcfDZ0tmNee9XVG1QiKXb1e/3G8ncntRW8wD2sg94hlznd3GhnmLbLQ64=,iv:vM1DCdVEflDuRusjWwMlNIF0RsDGLEaDSGtdHBBb5/A=,tag:URlOVc7uoBddyr0D6gCXiA==,type:str]
 kind: Secret
 metadata:
     creationTimestamp: null
     name: capacity-internal-client-secret
     namespace: capacity
 sops:
-    lastmodified: "2025-04-11T14:30:57Z"
-    mac: ENC[AES256_GCM,data:iXbc7sOFJ74eQh5qQ+fNauHl+grnPqFYLtL1HV5+Vb16EeyuEkhExHsNZW22jcOj6jTlItJn791w60Pbk9E+4UMHRy1xGhlAoHoVlNLVTWYAJkPAsBnFVphOcmyLJgDSZqLH0jg3Xl0EW1nQcUCIjhudBHsbwMabAFRiWvzJLeE=,iv:tu2Rs8CH193RjTLxA0FGSFVz2sKjYMKNpQqng/eJxf0=,tag:W6og11yxF87bt0DnvaQRfA==,type:str]
+    lastmodified: "2025-04-17T09:27:48Z"
+    mac: ENC[AES256_GCM,data:06libf/XrCvH+cJTq6aJUj4SEuskzICHftAhP5WA40EedLjZtPaGIjpvzKa/cMVdYHTOFRf9hdkYe19Fk6YS4v6XnzErRSeagQlm3e2YOwjQdY3o8KMptd9SsaE/GeWfzX237PTqOGsgCVbqkmZ666V2XwhBELup4IQL15zSlqk=,iv:K7Y40bbvsS8HsC03dpFfWS7TLKMP0OpIHSkbq+tVHNY=,tag:5lD9yljLq+oN2vqgrDJB1Q==,type:str]
     pgp:
-        - created_at: "2025-04-11T14:30:57Z"
+        - created_at: "2025-04-17T09:27:48Z"
           enc: |-
             -----BEGIN PGP MESSAGE-----
 
-            hF4DWK9rONmXZEsSAQdAKUrckZ4YtH8rquauqP2iut+W8qB4kGYFW25MY2GVv0cw
-            tRimGsuY6+exDrRKsTLG6svdDml4WMty29Que6XqRS0RcP+JDynWqlVXrnXoblNn
-            1GgBCQIQ2d7s6tlawRbecsoiJTmCxipZJ3SrW20qYIPjIjwcquruo83pyD+O0GTE
-            umWp39Lfz9Pf9KIlnrlZ4dnSc68ZWvWZB4pOjnyO1whgpFahqpq2L7L3ljOAAyXf
-            fwegJrLcHPcNJA==
-            =DPBT
+            hF4DWK9rONmXZEsSAQdAyDSDxzp1hcZCei4j0WRaUa1Oz1SM7PKVeMPznMlj/XYw
+            eyd1vThnAGYVJ11by7zQV98T0JAVCM4HD1wKCAXz86US2URxMzAXTMPX9EPoytpg
+            1GYBCQIQdoCdL/Jhkyl6MOTjJ4tfABXu4LGqiXS69sqVT9c0p00QCh+sFBHvZ2ME
+            9xSVp050S8gxkbRnvnLS9VcHyylYnLTcN0ZifW7ckTFNtTxcKwDgUA31Pruv2Lqn
+            Oq0YFzFgtbk=
+            =6T9q
             -----END PGP MESSAGE-----
           fp: BC3A767578FF432C7414DE6A73A07B99E207F7AF
     encrypted_regex: ^(data|stringData)$
-    version: 3.10.1
+    version: 3.10.2

--- a/clusters/l3-sqnc/secrets/capacity-internal-client-secret.yaml
+++ b/clusters/l3-sqnc/secrets/capacity-internal-client-secret.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+data:
+    key: ENC[AES256_GCM,data:kezqr/Tfd3RkO9lvcElksGfAJAJHqZSQF2a1/jE4xM6Rk4xJxeYb3gb8Nv8=,iv:Q+vp0CajZLXTLTzjKTJkFvMYEEHdBuLagTlIMjgNeYA=,tag:P2RRywcO2k/p66pkNufMNQ==,type:str]
+kind: Secret
+metadata:
+    creationTimestamp: null
+    name: capacity-internal-client-secret
+    namespace: capacity
+sops:
+    lastmodified: "2025-04-11T14:30:57Z"
+    mac: ENC[AES256_GCM,data:iXbc7sOFJ74eQh5qQ+fNauHl+grnPqFYLtL1HV5+Vb16EeyuEkhExHsNZW22jcOj6jTlItJn791w60Pbk9E+4UMHRy1xGhlAoHoVlNLVTWYAJkPAsBnFVphOcmyLJgDSZqLH0jg3Xl0EW1nQcUCIjhudBHsbwMabAFRiWvzJLeE=,iv:tu2Rs8CH193RjTLxA0FGSFVz2sKjYMKNpQqng/eJxf0=,tag:W6og11yxF87bt0DnvaQRfA==,type:str]
+    pgp:
+        - created_at: "2025-04-11T14:30:57Z"
+          enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            hF4DWK9rONmXZEsSAQdAKUrckZ4YtH8rquauqP2iut+W8qB4kGYFW25MY2GVv0cw
+            tRimGsuY6+exDrRKsTLG6svdDml4WMty29Que6XqRS0RcP+JDynWqlVXrnXoblNn
+            1GgBCQIQ2d7s6tlawRbecsoiJTmCxipZJ3SrW20qYIPjIjwcquruo83pyD+O0GTE
+            umWp39Lfz9Pf9KIlnrlZ4dnSc68ZWvWZB4pOjnyO1whgpFahqpq2L7L3ljOAAyXf
+            fwegJrLcHPcNJA==
+            =DPBT
+            -----END PGP MESSAGE-----
+          fp: BC3A767578FF432C7414DE6A73A07B99E207F7AF
+    encrypted_regex: ^(data|stringData)$
+    version: 3.10.1

--- a/clusters/l3-sqnc/secrets/optimiser-attachment-postgres-creds.yaml
+++ b/clusters/l3-sqnc/secrets/optimiser-attachment-postgres-creds.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+data:
+    password: ENC[AES256_GCM,data:1tf1dYA7E2SXmZKMLeIssHNBXaK+eHLG5SNRiH5YeI/OW54cpVXHnqoVNZusFqOB,iv:CWfV5l4xmikf13RSI09CXmTFb7G6iipyFHOMnnJ2usw=,tag:4GZwcN2v6OtlS3sgZp1Mkw==,type:str]
+kind: Secret
+metadata:
+    creationTimestamp: null
+    name: optimiser-attachment-postgres-creds
+    namespace: optimiser
+sops:
+    lastmodified: "2025-04-11T14:30:57Z"
+    mac: ENC[AES256_GCM,data:lEfnRnzndp+neHMH5S8dRnvAzi9dRFd+MON5GZxjtHyKN2gS9XMruigxkCDeg/end/DHhAXv7XxzbWf29ko3KBwnG+hB59GKmBHxJVRsaoXBt3w4UNOKudxxSVZ1Eeugo936UYKSBaOylFjHWvwOH8qN8SQC6g8DlPNv34ejo2E=,iv:JzA1rYUkQzUSnPJA+M7YrcLyi7Ki/0ZfTrYPFjPX4i4=,tag:m/+2wKTZZMr0OL5kEeCSHA==,type:str]
+    pgp:
+        - created_at: "2025-04-11T14:30:57Z"
+          enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            hF4DWK9rONmXZEsSAQdAygCm1cI+CLkIhU626jtQ7YS6lQB9wFWSGfOkgzYVJxsw
+            qihzANY0YdKxuDDlYrsXUyiH4yYjgjXZJqIKxiKiit6WJH2rQRcLDpNfTvLUJo+7
+            1GgBCQIQ/NcHAkm3kYF3R2P7KYwLS5Iw9pprCwXAb01INzWwVCR7LpJYDtV5v/aE
+            kxg5RSphPXfpK5rNbNR9eIiYiokD0K0CLNzoc5epNn3aBmxlr07giu1Ce0qK4kX3
+            AfSHHqcaObAl3w==
+            =8MWI
+            -----END PGP MESSAGE-----
+          fp: BC3A767578FF432C7414DE6A73A07B99E207F7AF
+    encrypted_regex: ^(data|stringData)$
+    version: 3.10.1

--- a/clusters/l3-sqnc/secrets/optimiser-client-secret.yaml
+++ b/clusters/l3-sqnc/secrets/optimiser-client-secret.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+data:
+    key: ENC[AES256_GCM,data:6TAIP0mt9OvhlIVVyBameBBzMlbhJT9BsMqH96ApvBz0NcphdglaISiUApA=,iv:Fy6blfyzsn2U5RTJ4OihtPQyOLfp3PhO2CsSnIlIKWo=,tag:gSvHBd/bIRm9HE3gXQOPcw==,type:str]
+kind: Secret
+metadata:
+    creationTimestamp: null
+    name: optimiser-client-secret
+    namespace: optimiser
+sops:
+    lastmodified: "2025-04-11T14:30:57Z"
+    mac: ENC[AES256_GCM,data:NOlin4vUEVuPo0T9AloVYuxWEkj8MzvNB3l4LiA34cIvBQ6HpkpjGlxST9qzwjdOSyEmb1UBpdFgoU9R0nLPu9mFzJVHCKN/HlfR7985BTaJOivTMkLqWXK4LfsdhJeJ20esuXPBqjwxPeKLBdsdOf7EY/qd6YcYFD3l2HAKsLE=,iv:YOrETGghr+H2xxYQfV+DF4U6J/ghV8iH1dOZkcudOVg=,tag:sLvoXHN66NNRdfIqw8higA==,type:str]
+    pgp:
+        - created_at: "2025-04-11T14:30:57Z"
+          enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            hF4DWK9rONmXZEsSAQdAlKUw+8lEg13NeFQyxaetIlDcSjuXNtMBf1sWEjH4y1Mw
+            QuaqBaZuqC+5v3PuFnYfJHcSEtVeSAMIklpjrvl+c4fN8j8RkjKN4tbO3QJuAX+s
+            1GYBCQIQPmu89khhQ78ySD0WAFIip2ZX+P5R01jH6Vp9ihF2vD5UKH/Uc3likWHI
+            Pb9boQ7sGPqPHDyEsmGHKqH5NwPrOfUL2yZbVVqQYyZ0Jps5s/zRqG+7O6Cr0ifi
+            t7AYVn2nsCs=
+            =dCiH
+            -----END PGP MESSAGE-----
+          fp: BC3A767578FF432C7414DE6A73A07B99E207F7AF
+    encrypted_regex: ^(data|stringData)$
+    version: 3.10.1

--- a/clusters/l3-sqnc/secrets/optimiser-internal-client-secret.yaml
+++ b/clusters/l3-sqnc/secrets/optimiser-internal-client-secret.yaml
@@ -1,26 +1,26 @@
 apiVersion: v1
 data:
-    key: ENC[AES256_GCM,data:s5UEp5LkA4EmbYQ3QPz7XFcmIiuex8FDyYBu+V2j9Jx8MXrmwfr2HCLknYM=,iv:uuwXqHB864tbyZRVvapVOvP1PtFxHSyqnXBuWcAL68g=,tag:jv78yRr5LQ6WMG2JO8dZLQ==,type:str]
+    key: ENC[AES256_GCM,data:L4uIv9svwcRxlKKBLxwhbtkdPs9pUQRnXagF+rh00u/60BkyPXyTdLk2GGg=,iv:cTGFKRdsB26gNHcyykmCdkat9Cstbzh0cYRhS9MWOpQ=,tag:IrVcRTzjwk7lGXjSmH/cZg==,type:str]
 kind: Secret
 metadata:
     creationTimestamp: null
     name: optimiser-internal-client-secret
     namespace: optimiser
 sops:
-    lastmodified: "2025-04-11T14:30:57Z"
-    mac: ENC[AES256_GCM,data:ETSBtXS0SdoyjCPhNn+o+leKIL6nggERVyTkoacg48IK+nDgTn3dzo4sUtyB3/8dmmXiXa7lC4hSEesqw73/UA7rHRlNElusEC4iB6qsLkqm12Z4V0wYPusobgRQjbBgA/G3t9LSeT7eMyYLDU4ra1oYOnpd+cz23wcJqhQU/lo=,iv:FUyB+EsSUg67N7vyEar7nVfLO4EeZoIIvq1fqIQPQF4=,tag:AjMa+m8EHqErPuSWBG1SJw==,type:str]
+    lastmodified: "2025-04-17T09:27:48Z"
+    mac: ENC[AES256_GCM,data:+Fcn/J/KuBKVBbehLj4+egJGD/LZxeFzgbvWMri4uuTr5EtFdvaz5dVF991aLMtvi6pdN5YSxnYAvZFB14fhYoCqIXzaELYl2BFPEvgxxY8RjTDdUCVoF4Jb1zVWhhbjtqHSJkYTmoNud6SZ4QWemIQqJOXv5i4dLhf0a0C19Us=,iv:9bJmykBB0UytY8hxxCSS8taWyc4c8K+x5xuK2tDRcXc=,tag:MERJJWoYC4sfxJCR0h6xrg==,type:str]
     pgp:
-        - created_at: "2025-04-11T14:30:57Z"
+        - created_at: "2025-04-17T09:27:48Z"
           enc: |-
             -----BEGIN PGP MESSAGE-----
 
-            hF4DWK9rONmXZEsSAQdAsXGAkGqBG13YWXJrEClzY+VpbFeYOSMt4q94LD/UCm4w
-            YHRqkmIS361SaMAVWtDxAaXCGkM/K5eZNdovwPPx5TOSLq8K5NxvgexduMUfGvQu
-            1GgBCQIQdOm+yOiv/m1Q0PhRofyC42jLZQMk1cW7RbPJ0BwHq95fUSy/MbL2nJnF
-            IDnTWBvxn6W7Rew2WDhyJBHBDuRtTTkLfVoc53O5QN2JgSONBOd6YZEogpGlm0ON
-            itZYv4lauMlrpw==
-            =hyww
+            hF4DWK9rONmXZEsSAQdAj5COtUummn5t/UCM0hWr0l9yd0jfjmCft9oMUKgukz0w
+            +AwJivu0R1uQ1Is5ilxpYBHIwVoPsUDbojlEGGS8/QZYZaxGY5HEA6xs59/o+jJ5
+            1GYBCQIQqny0NNgz+7osipFnbLvePrUyaJDaw6I2EIlgtQ+oIYpoon+fwZAtAh67
+            NHWyYos6nRgLkla/Felg5NXnL1/N28LH4rizn6kgkm/nlp7hnviUOf66mUJ62dXK
+            GiSwi6418/U=
+            =RYN1
             -----END PGP MESSAGE-----
           fp: BC3A767578FF432C7414DE6A73A07B99E207F7AF
     encrypted_regex: ^(data|stringData)$
-    version: 3.10.1
+    version: 3.10.2

--- a/clusters/l3-sqnc/secrets/optimiser-internal-client-secret.yaml
+++ b/clusters/l3-sqnc/secrets/optimiser-internal-client-secret.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+data:
+    key: ENC[AES256_GCM,data:s5UEp5LkA4EmbYQ3QPz7XFcmIiuex8FDyYBu+V2j9Jx8MXrmwfr2HCLknYM=,iv:uuwXqHB864tbyZRVvapVOvP1PtFxHSyqnXBuWcAL68g=,tag:jv78yRr5LQ6WMG2JO8dZLQ==,type:str]
+kind: Secret
+metadata:
+    creationTimestamp: null
+    name: optimiser-internal-client-secret
+    namespace: optimiser
+sops:
+    lastmodified: "2025-04-11T14:30:57Z"
+    mac: ENC[AES256_GCM,data:ETSBtXS0SdoyjCPhNn+o+leKIL6nggERVyTkoacg48IK+nDgTn3dzo4sUtyB3/8dmmXiXa7lC4hSEesqw73/UA7rHRlNElusEC4iB6qsLkqm12Z4V0wYPusobgRQjbBgA/G3t9LSeT7eMyYLDU4ra1oYOnpd+cz23wcJqhQU/lo=,iv:FUyB+EsSUg67N7vyEar7nVfLO4EeZoIIvq1fqIQPQF4=,tag:AjMa+m8EHqErPuSWBG1SJw==,type:str]
+    pgp:
+        - created_at: "2025-04-11T14:30:57Z"
+          enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            hF4DWK9rONmXZEsSAQdAsXGAkGqBG13YWXJrEClzY+VpbFeYOSMt4q94LD/UCm4w
+            YHRqkmIS361SaMAVWtDxAaXCGkM/K5eZNdovwPPx5TOSLq8K5NxvgexduMUfGvQu
+            1GgBCQIQdOm+yOiv/m1Q0PhRofyC42jLZQMk1cW7RbPJ0BwHq95fUSy/MbL2nJnF
+            IDnTWBvxn6W7Rew2WDhyJBHBDuRtTTkLfVoc53O5QN2JgSONBOd6YZEogpGlm0ON
+            itZYv4lauMlrpw==
+            =hyww
+            -----END PGP MESSAGE-----
+          fp: BC3A767578FF432C7414DE6A73A07B99E207F7AF
+    encrypted_regex: ^(data|stringData)$
+    version: 3.10.1

--- a/clusters/l3-sqnc/secrets/order-attachment-postgres-creds.yaml
+++ b/clusters/l3-sqnc/secrets/order-attachment-postgres-creds.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+data:
+    password: ENC[AES256_GCM,data:ngXfvyy4mI19P6AouV2F9dIb9IRCr5dNj8HYVjMASq1A589c4Ov/diXEAzBS6P17,iv:glfYqmL9musRopbw0SXxYmqff+v7JshaQ8uEbmDE9Qg=,tag:N9mm8fa1cF1Fr70wjAxg3g==,type:str]
+kind: Secret
+metadata:
+    creationTimestamp: null
+    name: order-attachment-postgres-creds
+    namespace: order
+sops:
+    lastmodified: "2025-04-11T14:30:57Z"
+    mac: ENC[AES256_GCM,data:r4hmzSwRdYxIT0w+puIOCo2YtYvwTqklmpHUc3pqeEcxVIseJTu7M7Su2tj9wcpIzepA5FYIG8MWo9nmVpbjzF5vZNwzA46l5hHYRBsmssV0Hxf1bHqO3eNeZVN4cvwRUxrXGq6/csWd4+woObb35OptWw+W2cCbeKNFbvGmMds=,iv:WqDCBEo1cVE100FViyGVshctAMTT9xzkj+xXWjnEgJI=,tag:jz0O3YRD1l5SDj8SDKGW9g==,type:str]
+    pgp:
+        - created_at: "2025-04-11T14:30:57Z"
+          enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            hF4DWK9rONmXZEsSAQdAw7Os5jTx5DhCRyB36hVXaMAbuFo80u0NN+JluWhQ2mww
+            C9w+nEyYLUZnx0Y2NPztfBwqr8qfvbtg8f6T4HUWTlaytZyxU/PfTWnaSMTJ/lDg
+            1GgBCQIQSWO5eDa4cntFtdYl35GkfNBOKjVIbF3FCKcUQnZ68jBm0o4cLn/nsPGI
+            n6XxqSjn2OFCFNuUw6wWzmF3fQHMdGvRGLi57d3dBIScYtWf3bXGWzCZwfZJmu4+
+            D54D+8U4TgR2EA==
+            =n7Ql
+            -----END PGP MESSAGE-----
+          fp: BC3A767578FF432C7414DE6A73A07B99E207F7AF
+    encrypted_regex: ^(data|stringData)$
+    version: 3.10.1

--- a/clusters/l3-sqnc/secrets/order-client-secret.yaml
+++ b/clusters/l3-sqnc/secrets/order-client-secret.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+data:
+    key: ENC[AES256_GCM,data:p7mxCTYgWracldWJaWuzCbDsKX2v5WV8iPA0Gr6ApurcpXJNTDYK1Vo3ELs=,iv:saGRc4gZ12JvO6Ym+UqdmeAuvh/oWUYdkIrLvU8dU6E=,tag:+7VG+9F/dMREp4wfOrGvTg==,type:str]
+kind: Secret
+metadata:
+    creationTimestamp: null
+    name: order-client-secret
+    namespace: order
+sops:
+    lastmodified: "2025-04-11T14:30:58Z"
+    mac: ENC[AES256_GCM,data:CQeSaGZPNZJPBRuXRDKuTHnkWzXryAQBXWSKCn8qmbYINcZDSFAQtatZmjknkWCtKd2aD0lZVRIwfv7qizfk/cqwHuz6+F2p29OyX3ybMQEu+lvaMXETl/1qyHFMC5CT7lI4lDDz1t+Qf3hJ/8V7UZXfLz1gOfNYXegmpf3s0TY=,iv:FxbFigmtDsduv3mQ3MSmMIjerBbuzvzMZbwovLu1pTk=,tag:AvOpzHrP67A0yVKvURsXVg==,type:str]
+    pgp:
+        - created_at: "2025-04-11T14:30:58Z"
+          enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            hF4DWK9rONmXZEsSAQdAL8fjCNPXn6s7aPhn2TEQaAy6k9k0CWon8v1fsJpNwH0w
+            TLAVm89m0zE5fujN/J8TYVIHNZU2YdHtGQkTN+W+FWyd/5BFdBGmgGvrJdIQF9FQ
+            1GgBCQIQh5DRANk/31c1NYX7QhSUCKiNwTE74yDU2Ux82aKD6I8C+m8FQr6iIfzG
+            9qQz2NjPL/ZC7ROT4g1OlEdAFtzuSseNdq7EtxwsDJjEb0hnhb03H/A/j62nf7ij
+            RasyF/GbqXP8gQ==
+            =9BUD
+            -----END PGP MESSAGE-----
+          fp: BC3A767578FF432C7414DE6A73A07B99E207F7AF
+    encrypted_regex: ^(data|stringData)$
+    version: 3.10.1

--- a/clusters/l3-sqnc/secrets/order-internal-client-secret.yaml
+++ b/clusters/l3-sqnc/secrets/order-internal-client-secret.yaml
@@ -1,26 +1,26 @@
 apiVersion: v1
 data:
-    key: ENC[AES256_GCM,data:ve+Tkvj8pJc+hv6b8WH//tpVry4fz9x8ZSv23qnpUrP85trs0FemVGira6A=,iv:SR0Pw9Knnovi2TBKer+Jj/pnnkRGstXy5+/2yW9dd04=,tag:H/VB+U+UsMgGU3uRwFH3PQ==,type:str]
+    key: ENC[AES256_GCM,data:/poTzFEtEdIly/ug6TQuSCPCAorkMju4hqHbMleyKV5jT9B6mAYFYHTUz8k=,iv:ukfa54EENcuShjwsefhy7QsLrAce6P3fVHqrT5/8Qbo=,tag:UkYGrCDTy+2MOirZduzjZg==,type:str]
 kind: Secret
 metadata:
     creationTimestamp: null
     name: order-internal-client-secret
     namespace: order
 sops:
-    lastmodified: "2025-04-11T14:30:58Z"
-    mac: ENC[AES256_GCM,data:tN4dfjxHal6DMGZfowVfrcFILz2A81Bpu3m2n7PPk/f4O3tFbuU3A3+0+NxHVattdg7V8ezzhKXK7yrrFN1PW913XyRbw2QKwNbaUEmhDkP8A3tEGBvrwLL5iKWoaUjdqptDV17VYC0N6iQEGkHfVtpZrB7aYrjFM0pM6Hf5ql4=,iv:lMf9dXnT+PllqYPBKR/I8gYD4PhJGIsQhPmAZw1vH+E=,tag:iw/cUvCJ+rE7FcvQOfizIw==,type:str]
+    lastmodified: "2025-04-17T09:27:48Z"
+    mac: ENC[AES256_GCM,data:O8qatmrHra0huZUkTiOXcvpV0OH9tDkXmJ2v0Xz8YYbv0z8MKuy2pMtqgULBo8hObf2EzP6Hr9JgrpcLbhQGR/veemmJZTfl9YNYOFOyEgEaDPmP5lK03Xx5P8toTZh4TKNCss5cjTDYVNji3ZjqWBY4C87RXiZUpZ70f3ivL98=,iv:BCAv/evNUaRSLGlAAS1iZwK23eggLSCSOHObkp2QzMY=,tag:5tgeNwUliwwPkSo3b7365w==,type:str]
     pgp:
-        - created_at: "2025-04-11T14:30:58Z"
+        - created_at: "2025-04-17T09:27:48Z"
           enc: |-
             -----BEGIN PGP MESSAGE-----
 
-            hF4DWK9rONmXZEsSAQdATNFTN1smHyPCjr9FAa2U0f9XgYfKDx6RBU4DJb0lAxQw
-            J24yOZJxYDbZdvw/IWCeRipv0EJaufYLZPDAHVfIhRnqvEZW0MNh1Rp7XMKfCwKW
-            1GgBCQIQl6kh7iI1Betd5SK1nLvnvmz3oktgYv9gDAvZRVD+7GqF+LgYLDY7xn9S
-            gxgMMrPRQlKsn/AzmvVX15/WMX6x1w9NHLT4ZkiFCH3hYOWzyMY+VqQWSzAIThbk
-            i9h4blqC8aBGnQ==
-            =bhk7
+            hF4DWK9rONmXZEsSAQdAvBs1sVQXw/uldepIP80l8brqP5ZVAK6zndLNCHV7Bjgw
+            JOIeMx+fVxKKnCE26NvODBcqsgmOXhaTGRY5CDFWgYfWWg8n8hOoFh8qR13tY/ZP
+            1GgBCQIQhnDK3SaRvEFAUFpel+MZMiZkTwAlsPpWkFMV4ue49CCWaOEgVrKxo/E2
+            xKaPd/q1Vbc8nx0wbRb3Mbw+AM5hkeDSj/oiU/DKtUjQztpbZkR259TTMNnzxtZb
+            KwKbMUi4uJJmxw==
+            =koOL
             -----END PGP MESSAGE-----
           fp: BC3A767578FF432C7414DE6A73A07B99E207F7AF
     encrypted_regex: ^(data|stringData)$
-    version: 3.10.1
+    version: 3.10.2

--- a/clusters/l3-sqnc/secrets/order-internal-client-secret.yaml
+++ b/clusters/l3-sqnc/secrets/order-internal-client-secret.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+data:
+    key: ENC[AES256_GCM,data:ve+Tkvj8pJc+hv6b8WH//tpVry4fz9x8ZSv23qnpUrP85trs0FemVGira6A=,iv:SR0Pw9Knnovi2TBKer+Jj/pnnkRGstXy5+/2yW9dd04=,tag:H/VB+U+UsMgGU3uRwFH3PQ==,type:str]
+kind: Secret
+metadata:
+    creationTimestamp: null
+    name: order-internal-client-secret
+    namespace: order
+sops:
+    lastmodified: "2025-04-11T14:30:58Z"
+    mac: ENC[AES256_GCM,data:tN4dfjxHal6DMGZfowVfrcFILz2A81Bpu3m2n7PPk/f4O3tFbuU3A3+0+NxHVattdg7V8ezzhKXK7yrrFN1PW913XyRbw2QKwNbaUEmhDkP8A3tEGBvrwLL5iKWoaUjdqptDV17VYC0N6iQEGkHfVtpZrB7aYrjFM0pM6Hf5ql4=,iv:lMf9dXnT+PllqYPBKR/I8gYD4PhJGIsQhPmAZw1vH+E=,tag:iw/cUvCJ+rE7FcvQOfizIw==,type:str]
+    pgp:
+        - created_at: "2025-04-11T14:30:58Z"
+          enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            hF4DWK9rONmXZEsSAQdATNFTN1smHyPCjr9FAa2U0f9XgYfKDx6RBU4DJb0lAxQw
+            J24yOZJxYDbZdvw/IWCeRipv0EJaufYLZPDAHVfIhRnqvEZW0MNh1Rp7XMKfCwKW
+            1GgBCQIQl6kh7iI1Betd5SK1nLvnvmz3oktgYv9gDAvZRVD+7GqF+LgYLDY7xn9S
+            gxgMMrPRQlKsn/AzmvVX15/WMX6x1w9NHLT4ZkiFCH3hYOWzyMY+VqQWSzAIThbk
+            i9h4blqC8aBGnQ==
+            =bhk7
+            -----END PGP MESSAGE-----
+          fp: BC3A767578FF432C7414DE6A73A07B99E207F7AF
+    encrypted_regex: ^(data|stringData)$
+    version: 3.10.1


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [x] Chore
- [x] Feature

## Linked tickets

SQNC-157

## High level description

On production, we've got two SQNC services to upgrade across major versions and an entirely new service to add. This PR is to update the matchmaker API to v5.1.2, the identity service to v4.0.2, and introduce v2.0.0 of the attachment API. To facilitate this, we've also rolled the PostgreSQL sub-charts in the existing services back to v16, as there's no straightforward method to upgrade them once in flight on Kubernetes across major PostgreSQL versions.
