### PR TITLE
Added automerge to workflow on success

### DIFF
--- a/.github/workflows/validate-kind.yaml
+++ b/.github/workflows/validate-kind.yaml
@@ -21,6 +21,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   kubernetes:
     runs-on: ubuntu-latest
@@ -31,7 +35,7 @@ jobs:
         uses: Homebrew/actions/setup-homebrew@master
       - name: Install Flux
         run: |
-          brew install fluxcd/tap/flux@2.3
+          brew install fluxcd/tap/flux@2.5.1
           flux -v
       - name: Init Kind action
         uses: helm/kind-action@v1.12.0
@@ -121,6 +125,14 @@ jobs:
             -f head_sha=$(git log -n 1 ${GITHUB_REF#refs/heads/} --pretty=format:"%H") \
             -f status="completed" \
             -f conclusion="success"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Auto-merge PR into main
+        if: github.event_name == 'pull_request' && startsWith(github.head_ref, 'renovate/') && success()
+        run: |
+          PR_NUMBER=$(gh pr view --json number -q .number)
+          echo "Merging PR #$PR_NUMBER into main"
+          gh pr merge $PR_NUMBER --squash --admin --delete-branch
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Describe failing pods


### PR DESCRIPTION
Set workflow permissions

Changed flux version to match staging/prod

# Pull Request

## Checklist
- [X] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [X] Chore

## Linked tickets

N.A

## High level description

Allows automerging into the kind cluster

## Detailed description

Adds a step that automerges successful renovate PRs into `main`
Upgrades flux to `2.5.1` as we have in staging/prod.
Changes workflow permissions.



## Describe alternatives you've considered

As we are modifying the branches that renovate creates, we cannot automerge them using renovate.  One alternative is, instead of us modifying the renovate branch, the `validate-kind` workflow cuts a branch from each renovate PR, modifies that surrogate branch to test and then completes if successful, this would allow automerge to work as we are not modifying its original branch.

## Operational impact

<!--- A description of any operational considerations associated with the change. Is there anything in particular we should be looking at when deploying the change to make sure it is working as intended. If something goes wrong will any special actions be needed to revert the change. -->

## Additional context

<!-- Add any other context or screenshots about the feature request here. -->
