### PR TITLE
Bug/monitoring sync healthchecks

### DIFF
--- a/.github/workflows/validate-kind.yaml
+++ b/.github/workflows/validate-kind.yaml
@@ -31,12 +31,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@main
-      - name: Init Homebrew
-        uses: Homebrew/actions/setup-homebrew@master
       - name: Install Flux
-        run: |
-          brew install fluxcd/tap/flux@2.5.1
-          flux -v
+        uses: fluxcd/flux2/action@main
       - name: Init Kind action
         uses: helm/kind-action@v1.12.0
         with:

--- a/clusters/kind-cluster/base/app-sync.yaml
+++ b/clusters/kind-cluster/base/app-sync.yaml
@@ -84,18 +84,22 @@ spec:
     name: flux-system
     namespace: flux-system
   healthChecks:
-    - apiVersion: apiextensions.k8s.io/v1
-      kind: CustomResourceDefinition
-      name: podmonitors.monitoring.coreos.com
-    - apiVersion: apiextensions.k8s.io/v1
-      kind: CustomResourceDefinition
-      name: servicemonitors.monitoring.coreos.com
-    - apiVersion: apiextensions.k8s.io/v1
-      kind: CustomResourceDefinition
-      name: instrumentations.opentelemetry.io
-    - apiVersion: apiextensions.k8s.io/v1
-      kind: CustomResourceDefinition
-      name: opentelemetrycollectors.opentelemetry.io
+    - apiVersion: helm.toolkit.fluxcd.io/v2beta1
+      kind: HelmRelease
+      name: otel
+      namespace: monitoring
+    - apiVersion: helm.toolkit.fluxcd.io/v2beta1
+      kind: HelmRelease
+      name: jaeger
+      namespace: monitoring
+    - apiVersion: helm.toolkit.fluxcd.io/v2beta1
+      kind: HelmRelease
+      name: promtail
+      namespace: monitoring
+    - apiVersion: helm.toolkit.fluxcd.io/v2beta1
+      kind: HelmRelease
+      name: kube-prometheus-stack
+      namespace: monitoring
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization

--- a/clusters/kind-cluster/base/app-sync.yaml
+++ b/clusters/kind-cluster/base/app-sync.yaml
@@ -74,6 +74,7 @@ metadata:
   namespace: monitoring
 spec:
   interval: 1m
+  timeout: 3m
   path: ./clusters/kind-cluster/monitoring
   prune: true
   dependsOn:

--- a/clusters/kind-cluster/base/app-sync.yaml
+++ b/clusters/kind-cluster/base/app-sync.yaml
@@ -124,3 +124,8 @@ spec:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2beta1
+      kind: HelmRelease
+      name: cert-manager
+      namespace: cert-manager

--- a/clusters/kind-cluster/base/flux-system/gotk-sync.yaml
+++ b/clusters/kind-cluster/base/flux-system/gotk-sync.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: main
+    branch: bug/monitoring-sync-healthchecks
   url: https://github.com/digicatapult/sqnc-flux-infra.git
 
 ---

--- a/clusters/kind-cluster/base/flux-system/gotk-sync.yaml
+++ b/clusters/kind-cluster/base/flux-system/gotk-sync.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: bug/monitoring-sync-healthchecks
+    branch: main
   url: https://github.com/digicatapult/sqnc-flux-infra.git
 
 ---


### PR DESCRIPTION
# Pull Request

## Checklist
- [X] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [X] Bug Fix

## Linked tickets

<!-- If this PR is linked to a JIRA ticket or Github Issue, please provide the ticket URL here. -->

## High level description

Adds useful kustomization health checks so that kustomizations are not marked as ready (and subsequent helmreleases do not install) until all dependent services are marked as active.

## Detailed description

The monitoring-sync kustomization was marked as healthy, causing alice,bob and charlie syncs to start installing applications before all of the necessary pre-requisites were installed and functioning.


## Describe alternatives you've considered

<!-- A clear and concise description of the alternative solutions you've considered. Be sure to explain why the existing customisability isn't suitable for this feature. -->

## Operational impact

<!--- A description of any operational considerations associated with the change. Is there anything in particular we should be looking at when deploying the change to make sure it is working as intended. If something goes wrong will any special actions be needed to revert the change. -->

## Additional context

<!-- Add any other context or screenshots about the feature request here. -->
