### PR TITLE
Update validate-kind.yaml

### DIFF
--- a/.github/workflows/validate-kind.yaml
+++ b/.github/workflows/validate-kind.yaml
@@ -11,11 +11,6 @@ on:
       - 'renovate/**'
     paths:
       - 'clusters/kind-cluster/**'
-  push:
-    branches:
-      - 'renovate/**'
-    paths:
-      - 'clusters/kind-cluster/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Remove push workflow execution so it only executes on PR

# Pull Request

## Checklist
- [X] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [X] Bug Fix

## Linked tickets

<!-- If this PR is linked to a JIRA ticket or Github Issue, please provide the ticket URL here. -->

## High level description

The workflow appears to be executed by push instead of by PR which is required for the auto-merging elements to work

## Detailed description

<!-- A detailed description of the feature and if possible describe how has been implemented. -->


## Describe alternatives you've considered

<!-- A clear and concise description of the alternative solutions you've considered. Be sure to explain why the existing customisability isn't suitable for this feature. -->

## Operational impact

<!--- A description of any operational considerations associated with the change. Is there anything in particular we should be looking at when deploying the change to make sure it is working as intended. If something goes wrong will any special actions be needed to revert the change. -->

## Additional context

<!-- Add any other context or screenshots about the feature request here. -->
