### PR TITLE
Use GITHUB_HEAD_REF for PR branches

### DIFF
--- a/.github/workflows/validate-kind.yaml
+++ b/.github/workflows/validate-kind.yaml
@@ -62,7 +62,7 @@ jobs:
       - name: Patch GitOps branch to match PR
         if: success()
         run: |
-          patch=${GITHUB_REF#refs/heads/}
+          patch=${GITHUB_HEAD_REF}
           sed -i -r "s#(branch:).*#\1 $patch#" \
             ./clusters/kind-cluster/base/flux-system/gotk-sync.yaml
           git add ./clusters/kind-cluster/base/flux-system/gotk-sync.yaml
@@ -74,11 +74,11 @@ jobs:
           flux suspend kustomization --all
           flux create source git flux-system \
           --url=${{ github.event.repository.html_url }} \
-          --branch=${GITHUB_REF#refs/heads/} \
+          --branch=${GITHUB_HEAD_REF} \
           --username=${GITHUB_ACTOR} \
           --password=${{ secrets.GITHUB_TOKEN }}
           flux resume kustomization --all
-          message=$(echo ${GITHUB_REF#refs/heads/}"@sha1:"$(git log -n 1 ${GITHUB_REF#refs/heads/} --pretty=format:"%H"))
+          message=$(echo ${GITHUB_HEAD_REF}"@sha1:"$(git log -n 1 ${GITHUB_HEAD_REF} --pretty=format:"%H"))
           kubectl wait kustomization --all --all-namespaces --for='jsonpath={.status.conditions[?(@.type=="Ready")].message}=Applied revision: '"$message" --timeout=10m
           kubectl get kustomizations -A
           kubectl wait helmrelease --all --all-namespaces --for=condition=ready --timeout=10m
@@ -112,11 +112,11 @@ jobs:
             ./clusters/kind-cluster/base/flux-system/gotk-sync.yaml
           git add ./clusters/kind-cluster/base/flux-system/gotk-sync.yaml
           git commit -am "Return GitOps branch to main"
-          git push -u origin ${GITHUB_REF#refs/heads/} && \
+          git push -u origin ${GITHUB_HEAD_REF} && \
           gh api --method POST -H "Accept: application/vnd.github+json" \
             /repos/${{ github.repository }}/check-runs \
             -f name="gotk-sync.yaml status check" \
-            -f head_sha=$(git log -n 1 ${GITHUB_REF#refs/heads/} --pretty=format:"%H") \
+            -f head_sha=$(git log -n 1 ${GITHUB_HEAD_REF} --pretty=format:"%H") \
             -f status="completed" \
             -f conclusion="success"
         env:


### PR DESCRIPTION
# Pull Request

## Checklist
- [X] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [X] Bug Fix

## Linked tickets

<!-- If this PR is linked to a JIRA ticket or Github Issue, please provide the ticket URL here. -->

## High level description

When we execute something via a PR, it gives a PR number as the REF in a detached head state.  Instead we need to use `GITHUB_HEAD_REF` for the branch HEAD.

## Detailed description

<!-- A detailed description of the feature and if possible describe how has been implemented. -->


## Describe alternatives you've considered

<!-- A clear and concise description of the alternative solutions you've considered. Be sure to explain why the existing customisability isn't suitable for this feature. -->

## Operational impact

<!--- A description of any operational considerations associated with the change. Is there anything in particular we should be looking at when deploying the change to make sure it is working as intended. If something goes wrong will any special actions be needed to revert the change. -->

## Additional context

<!-- Add any other context or screenshots about the feature request here. -->
