### PR TITLE
Upgrade nodes/services on staging

### DIFF
--- a/clusters/sqnc-staging/base/flux-system/gotk-sync.yaml
+++ b/clusters/sqnc-staging/base/flux-system/gotk-sync.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: main
+    branch: chore/upgrade_staging_node_7.1.16
   url: https://github.com/digicatapult/sqnc-flux-infra.git
 
 ---

--- a/clusters/sqnc-staging/base/flux-system/gotk-sync.yaml
+++ b/clusters/sqnc-staging/base/flux-system/gotk-sync.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: chore/upgrade_staging_node_7.1.16
+    branch: main
   url: https://github.com/digicatapult/sqnc-flux-infra.git
 
 ---

--- a/clusters/sqnc-staging/match2/yellow-node/release.yaml
+++ b/clusters/sqnc-staging/match2/yellow-node/release.yaml
@@ -15,7 +15,7 @@ spec:
     enable: true
   chart:
     spec:
-      version: 7.1.5
+      version: 7.1.16
       chart: sqnc-node
       sourceRef:
         kind: HelmRepository

--- a/clusters/sqnc-staging/match2/yellow-node/release.yaml
+++ b/clusters/sqnc-staging/match2/yellow-node/release.yaml
@@ -15,7 +15,7 @@ spec:
     enable: true
   chart:
     spec:
-      version: 7.1.16
+      version: 7.1.18
       chart: sqnc-node
       sourceRef:
         kind: HelmRepository


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [x] Chore

## Linked tickets

SQNC-128

## High level description

This ticket requires the following upgrades to the nodes and services on staging to ensure that they're the latest versions:

1. Node: 7.1.18
2. Identity service: 5.1.18
3. Attachment API: 3.0.6
4. Matchmaker API: 4.0.49
5. IPFS: 4.0.46
6. Open API merger: 2.1.76

Only the attachment API has a major version change. All of the other upgrades are patches.

Production will be upgraded in a separate PR.