### PR TITLE
Upgrade Keycloak to v26 on Kind

### DIFF
--- a/clusters/kind-cluster/base/flux-system/gotk-sync.yaml
+++ b/clusters/kind-cluster/base/flux-system/gotk-sync.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: main
+    branch: chore/upgrade_keycloak_kind
   url: https://github.com/digicatapult/sqnc-flux-infra.git
 
 ---

--- a/clusters/kind-cluster/keycloak/release.yaml
+++ b/clusters/kind-cluster/keycloak/release.yaml
@@ -14,7 +14,7 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: bitnami-broadcom
-      version: "22.2.6"
+      version: "24.6.4"
   interval: 10m0s
   # Default values
   # https://github.com/bitnami/charts/blob/master/bitnami/keycloak/values.yaml

--- a/clusters/kind-cluster/keycloak/release.yaml
+++ b/clusters/kind-cluster/keycloak/release.yaml
@@ -14,7 +14,7 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: bitnami-broadcom
-      version: "21.8.0"
+      version: "22.2.6"
   interval: 10m0s
   # Default values
   # https://github.com/bitnami/charts/blob/master/bitnami/keycloak/values.yaml

--- a/clusters/kind-cluster/keycloak/values.yaml
+++ b/clusters/kind-cluster/keycloak/values.yaml
@@ -4,13 +4,9 @@ ingress:
   enabled: true
   hostname: localhost
 extraEnvVars:
-  - name: KC_HOSTNAME_PATH
-    value: /auth/
-  - name: KC_HOSTNAME_PORT
-    value: "3080"
-  - name: KC_HOSTNAME_ADMIN_URL
+  - name: KC_HOSTNAME_ADMIN
     value: "http://localhost:3080/auth/"
-  - name: KC_HOSTNAME_URL
+  - name: KC_HOSTNAME
     value: "http://localhost:3080/auth/"
   - name: KC_HOSTNAME_DEBUG
     value: "true"

--- a/clusters/kind-cluster/keycloak/values.yaml
+++ b/clusters/kind-cluster/keycloak/values.yaml
@@ -1,5 +1,5 @@
 httpRelativePath: /auth/
-proxy: edge
+proxyHeaders: xforwarded
 ingress:
   enabled: true
   hostname: localhost


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [x] Chore

## Linked tickets

SQNC-112

## High level description

This PR upgrades from Keycloak v24 to v26, removing deprecated options. Hostnames were simplified in v25 to accept the bare URLs for authentication: `KC_HOSTNAME` and `KC_HOSTNAME_ADMIN`, removing the extra port and auth variables entirely. In v25, the `proxy` field was flagged as deprecated and then removed in v26. It was replaced by the `proxyHeaders` option, which can take either `forwarded` or `xforwarded`.

## Operational impact

There is a breaking change in Bitnami's Keycloak chart, where it switches from PostgreSQL v16 to v17. This prevents a straightforward upgrade out-of-the-box and requires a backup and restore process, typically by bringing up a new cluster that's already matched to the target PostgreSQL release (v17) to ensure that a PVC exists with the correct data layout. We'd then scaled down the Keycloak statefulset, delete the original pod and PVCs, and update the release.yaml for the deployment. Once that's reconciled, we'd scale Keycloak back up and restore data for the existing deployment from the auxiliary PVC.