### PR TITLE
Upgrade Keycloak on production to v26

### DIFF
--- a/clusters/l3-sqnc/base/flux-system/gotk-sync.yaml
+++ b/clusters/l3-sqnc/base/flux-system/gotk-sync.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: main
+    branch: chore/upgrade_production_keycloak_v26
   url: https://github.com/digicatapult/sqnc-flux-infra.git
 
 ---

--- a/clusters/l3-sqnc/base/flux-system/gotk-sync.yaml
+++ b/clusters/l3-sqnc/base/flux-system/gotk-sync.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: chore/upgrade_production_keycloak_v26
+    branch: main
   url: https://github.com/digicatapult/sqnc-flux-infra.git
 
 ---

--- a/clusters/l3-sqnc/capacity/open-api-merger/values.yaml
+++ b/clusters/l3-sqnc/capacity/open-api-merger/values.yaml
@@ -29,6 +29,8 @@ securitySchema:
       match2:cancel: "Cancel match2"
       match2:accept: "Accept match2"
       match2:reject: "Reject match2"
+persistence:
+  enabled: false
 ingress:
   ingressClassName: nginx-capacity
   enabled: true

--- a/clusters/l3-sqnc/keycloak/keycloak/release.yaml
+++ b/clusters/l3-sqnc/keycloak/keycloak/release.yaml
@@ -10,11 +10,11 @@ spec:
   releaseName: keycloak
   chart:
     spec:
-      version: 21.3.1
+      version: 22.2.6
       chart: keycloak
       sourceRef:
         kind: HelmRepository
-        name: bitnami
+        name: bitnami-oci
   interval: 10m0s
   # Default values
   # https://github.com/bitnami/charts/blob/master/bitnami/keycloak/values.yaml

--- a/clusters/l3-sqnc/keycloak/keycloak/release.yaml
+++ b/clusters/l3-sqnc/keycloak/keycloak/release.yaml
@@ -10,7 +10,7 @@ spec:
   releaseName: keycloak
   chart:
     spec:
-      version: 22.2.6
+      version: 24.6.7
       chart: keycloak
       sourceRef:
         kind: HelmRepository

--- a/clusters/l3-sqnc/keycloak/keycloak/values.yaml
+++ b/clusters/l3-sqnc/keycloak/keycloak/values.yaml
@@ -2,7 +2,7 @@ global:
   imagePullSecrets:
     - name: dockerhub
 production: true
-proxy: edge
+proxyHeaders: forwarded
 ingress:
   enabled: true
   ingressClassName: nginx-keycloak
@@ -14,9 +14,9 @@ adminIngress:
 auth:
   adminUser: "admin"
 extraEnvVars:
-  - name: KC_HOSTNAME_ADMIN_URL
+  - name: KC_HOSTNAME_ADMIN
     value: "https://auth.dsch-l3.com/"
-  - name: KC_HOSTNAME_URL
+  - name: KC_HOSTNAME
     value: "https://auth.dsch-l3.com/"
   - name: KC_HOSTNAME_DEBUG
     value: "true"
@@ -38,7 +38,7 @@ postgresql:
       storageClass: managed-csi-premium
       size: 5Gi
   metrics:
-  enabled: true
+    enabled: true
   serviceMonitor:
     enabled: true
     namespace: keycloak

--- a/clusters/l3-sqnc/optimiser/open-api-merger/values.yaml
+++ b/clusters/l3-sqnc/optimiser/open-api-merger/values.yaml
@@ -29,6 +29,8 @@ securitySchema:
       match2:cancel: "Cancel match2"
       match2:accept: "Accept match2"
       match2:reject: "Reject match2"
+persistence:
+  enabled: false
 ingress:
   ingressClassName: nginx-optimiser
   enabled: true

--- a/clusters/l3-sqnc/order/open-api-merger/values.yaml
+++ b/clusters/l3-sqnc/order/open-api-merger/values.yaml
@@ -29,6 +29,8 @@ securitySchema:
       match2:cancel: "Cancel match2"
       match2:accept: "Accept match2"
       match2:reject: "Reject match2"
+persistence:
+  enabled: false
 ingress:
   ingressClassName: nginx-order
   enabled: true


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [x] Chore
- [x] Breaking Change (fix or feature that would cause existing functionality to change)

## Linked tickets

SQNC-112

## High level description

We've a couple of major versions of Keycloak to deploy to production, and with v26 there is a breaking change with the PostgreSQL dependency in switching from v16 to v17, the process for which largely involves an out-of-band installation to provide the dump for `pg_dumpall`/`psql`.  There are also several variables to update due to deprecation: `proxy` is partly replaced by `proxyHeaders` while `KC_HOSTNAME` and `KC_HOSTNAME_ADMIN` take URLs and consolidate the various individual port, URL, and path environment variables that existed previously.