### PR TITLE
Add index cleaner job

### DIFF
--- a/clusters/sqnc-staging/base/flux-system/gotk-sync.yaml
+++ b/clusters/sqnc-staging/base/flux-system/gotk-sync.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: main
+    branch: feature/add_elasticsearch_index_cleaner
   url: https://github.com/digicatapult/sqnc-flux-infra.git
 
 ---

--- a/clusters/sqnc-staging/monitoring/jaeger/values.yaml
+++ b/clusters/sqnc-staging/monitoring/jaeger/values.yaml
@@ -89,3 +89,14 @@ query:
           secretKeyRef:
             name: oauth2-proxy-cookie-secret
             key: secret
+esIndexCleaner:
+  enabled: true
+  image:
+    repository: jaegertracing/jaeger-es-index-cleaner
+    pullPolicy: IfNotPresent
+    tag: "latest"
+  schedule: "0 11 * * *"
+  numberOfDays: 30
+  serviceAccount:
+    create: true
+    name: jaeger-elasticsearch-cleaner

--- a/clusters/sqnc-staging/secrets/jaeger-elasticsearch.yaml
+++ b/clusters/sqnc-staging/secrets/jaeger-elasticsearch.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+data:
+    password: ENC[AES256_GCM,data:yWWd9JG9EjCBbKMEUT+4VwmoRK4sC8nS,iv:9iH6KiRVPP07AGm6MooC7amjtL3XIDhbvgABVBEIP7Y=,tag:9m/fltmhUMQBmK2OX2SVxA==,type:str]
+    username: ENC[AES256_GCM,data:FVKF7+z+BaK9fn1E,iv:hRCGMzoX1bU60ft4qDBFi2pEOGNWKUMsgZnBNueqpiw=,tag:qTY+DhZM/utfZaZ/RHVPlw==,type:str]
+kind: Secret
+metadata:
+    creationTimestamp: null
+    name: jaeger-elasticsearch
+    namespace: monitoring
+sops:
+    lastmodified: "2025-06-02T15:43:32Z"
+    mac: ENC[AES256_GCM,data:wARLUgxwVARDKQfgYwWG39HHdqZ2z+vFtNevV8SgIXFhnoCEGS9/gM2ETuMBivJRLgmBwMplzba2gI9YhgwmZcdUh63+dARqtasoiNi1K5HxAOcy+k722JL7SlvflUXjOowhNCU3mRQ/cGd/HhrBGzy6D7dONeawxDdEnuxQnEI=,iv:nrDFel/p+G/BUfwKWGeu8C7cv1Yn0j5xSo1CE7YvFpo=,tag:seoHIpCKU4ZIk2NCrMPJRA==,type:str]
+    pgp:
+        - created_at: "2025-06-02T15:43:32Z"
+          enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            hF4DUwQKXS8ls7oSAQdAWGN53WtZ0H97QKFTb5MaBHII9uXPxv+Np+zsAN1QxT4w
+            j1GBsiY1fa5zSgQaxQD5sMw5mDG3YXJjpYIBKpUFNyzg7y9eFjhRXWPWW4MvNvjD
+            1GgBCQIQ1nRPPQH7mLEPnVKce8hUZbg5LZ/HFor6VrY6TcP0ltb0h0Kj9M2vQCY9
+            o59nLdC3eFPkjHhkk/YJ98KY39b79YHoNBvodqoOxD1ckfzqonTI6Fu64R9ndLUi
+            AFN/jSFotOc3kA==
+            =NxX7
+            -----END PGP MESSAGE-----
+          fp: 025EED3A1FBD8A5CE8A150C56DC71B2AE79A5F9B
+    encrypted_regex: ^(data|stringData)$
+    version: 3.10.2


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [x] Feature

## Linked tickets

SQNC-186
SQNC-187

## High level description

This PR adds the index cleaner job to the Jaeger stack, allowing us to prune the ElasticSearch indexes and relieve any disk pressure that builds up over time.

## Operational impact

Between April and May, the average index grew in size to about 3 GB. Given that each disk is 100 GB, a 30-day window shouldn't result in any pressure for the time being. That window could still be reduced, if necessary.