### PR TITLE
Add index cleaner to production

### DIFF
--- a/clusters/l3-sqnc/base/flux-system/gotk-sync.yaml
+++ b/clusters/l3-sqnc/base/flux-system/gotk-sync.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: main
+    branch: feature/add_elasticsearch_index_cleaner_to_production
   url: https://github.com/digicatapult/sqnc-flux-infra.git
 
 ---

--- a/clusters/l3-sqnc/base/flux-system/gotk-sync.yaml
+++ b/clusters/l3-sqnc/base/flux-system/gotk-sync.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: feature/add_elasticsearch_index_cleaner_to_production
+    branch: main
   url: https://github.com/digicatapult/sqnc-flux-infra.git
 
 ---

--- a/clusters/l3-sqnc/monitoring/jaeger/values.yaml
+++ b/clusters/l3-sqnc/monitoring/jaeger/values.yaml
@@ -98,3 +98,14 @@ query:
           secretKeyRef:
             name: oauth2-proxy-cookie-secret
             key: secret
+esIndexCleaner:
+  enabled: true
+  image:
+    repository: jaegertracing/jaeger-es-index-cleaner
+    pullPolicy: IfNotPresent
+    tag: "latest"
+  schedule: "0 3 * * *"
+  numberOfDays: 30
+  serviceAccount:
+    create: true
+    name: jaeger-elasticsearch-cleaner

--- a/clusters/l3-sqnc/secrets/jaeger-elasticsearch.yaml
+++ b/clusters/l3-sqnc/secrets/jaeger-elasticsearch.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+data:
+    password: ENC[AES256_GCM,data:+OuraNBLuifujj/XQfb8B7fgovz7eCq/Irge1uA8Nk4=,iv:f53U/q0VTENrE+7gPNhfwQ/v1t0CNOGRyyW0th+xOvE=,tag:1yKzg0dQ8fOu7pKHXrbG3g==,type:str]
+    username: ENC[AES256_GCM,data:pSAyLiWpj2GV/Msg,iv:UJpy68NwHi4ixu76qDlTq7/WVHWE+JC6ufk7A8KDCyQ=,tag:eeipsuP/GbfbtfZCU0jU9A==,type:str]
+kind: Secret
+metadata:
+    creationTimestamp: null
+    name: jaeger-elasticsearch
+    namespace: monitoring
+sops:
+    lastmodified: "2025-06-04T12:45:55Z"
+    mac: ENC[AES256_GCM,data:wtKZLLljmykSj+27vNMpieFIjajvo68FClbfPiUyEba/cRGVV/Hz8pT6uN8+tuyJcRnVnM7fkT/xrHT2cKI934nv7U3TK6e+Jz1jzlpF/+H/3Ee3mdvDD+c3YGnYR14uPj8F/9VqwiMnjtYeVanvGN+/2fVwrWk2gg3dZPclNfQ=,iv:3V2pKeElR2VVnDlS9LKhnfPGeJMVt1287cM9408iYps=,tag:VpJ+BAa87GVAnkLiNWnRYg==,type:str]
+    pgp:
+        - created_at: "2025-06-04T12:45:55Z"
+          enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            hF4DWK9rONmXZEsSAQdABG+kCottSnPg5CR5xGmfGEw8iwT2jq6hfLICIKhPix4w
+            nVLvrM6McLr0jKZNDph67bSaApQT7uopArZ8iyW7gUmMuLDghwDUFihQQ7gRw3Z/
+            1GYBCQIQfOxhUIwvGWLbRdBxk3kac1qwZ/v2VphQeA59+4rlVfRC46rhBw63CAbw
+            zYw4msN5guaA8C002MFm8i5YlZg6zefsrxKFMiGMqmHvroBuIwaFvAIiCNfukjht
+            DHanmBQbLy4=
+            =T8Lm
+            -----END PGP MESSAGE-----
+          fp: BC3A767578FF432C7414DE6A73A07B99E207F7AF
+    encrypted_regex: ^(data|stringData)$
+    version: 3.10.2


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [x] Feature

## Linked tickets

SQNC-186
SQNC-187

## High level description

This PR adds the index cleaner job to the Jaeger stack, allowing us to prune the ElasticSearch indexes and relieve any disk pressure that builds up over time.

## Operational impact

Between April and May, the average index grew in size to about 3 GB. Given that each disk is 100 GB, a 30-day window shouldn't result in any pressure for the time being. That window could still be reduced, if necessary.