### PR TITLE
Replace bitnami/cert-manager in production

### DIFF
--- a/clusters/l3-sqnc/base/flux-system/gotk-sync.yaml
+++ b/clusters/l3-sqnc/base/flux-system/gotk-sync.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: chore/replace_bitnami_cert_manager_in_production
+    branch: main
   url: https://github.com/digicatapult/sqnc-flux-infra.git
 
 ---

--- a/clusters/l3-sqnc/base/flux-system/gotk-sync.yaml
+++ b/clusters/l3-sqnc/base/flux-system/gotk-sync.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: main
+    branch: chore/replace_bitnami_cert_manager_in_production
   url: https://github.com/digicatapult/sqnc-flux-infra.git
 
 ---

--- a/clusters/l3-sqnc/cert-manager/release.yaml
+++ b/clusters/l3-sqnc/cert-manager/release.yaml
@@ -11,14 +11,14 @@ spec:
   releaseName: cert-manager
   chart:
     spec:
-      version: 1.3.0
+      version: 1.18.2
       chart: cert-manager  
       sourceRef:
         kind: HelmRepository
-        name: bitnami
+        name: cert-manager
   interval: 10m0s
   # Default values
-  # https://github.com/bitnami/charts/blob/master/bitnami/cert-manager/values.yaml
+  # https://github.com/cert-manager/cert-manager/blob/master/deploy/charts/cert-manager/values.yaml
   valuesFrom:
     - kind: ConfigMap
       name: cert-manager-values

--- a/clusters/l3-sqnc/cert-manager/source.yaml
+++ b/clusters/l3-sqnc/cert-manager/source.yaml
@@ -7,3 +7,12 @@ metadata:
 spec:
   interval: 10m
   url: https://charts.bitnami.com/bitnami
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: cert-manager
+  namespace: cert-manager
+spec:
+  interval: 10m
+  url: https://charts.jetstack.io

--- a/clusters/l3-sqnc/cert-manager/values.yaml
+++ b/clusters/l3-sqnc/cert-manager/values.yaml
@@ -1,4 +1,7 @@
 # https://github.com/cert-manager/cert-manager/blob/master/deploy/charts/cert-manager/values.yaml
+global:
+  imagePullSecrets:
+    - name: dockerhub
 crds:
   keep: true
   enabled: true

--- a/clusters/l3-sqnc/cert-manager/values.yaml
+++ b/clusters/l3-sqnc/cert-manager/values.yaml
@@ -1,27 +1,19 @@
-installCRDs: true
-global:
-  imagePullSecrets:
-    - name: dockerhub
-  security:
-    allowInsecureImages: true
-metrics:
+# https://github.com/cert-manager/cert-manager/blob/master/deploy/charts/cert-manager/values.yaml
+crds:
+  keep: true
   enabled: true
-  serviceMonitor:
+prometheus:
+  servicemonitor:
     enabled: true
     namespace: cert-manager
-    relabelings:
+    targetPort: 9402
+    endpointAdditionalProperties:
+      relabelings:
       - action: replace
         sourceLabels: [namespace]
         targetLabel: kubernetes_namespace
-controller:
-  image:
-    repository: bitnamilegacy/cert-manager
-  acmesolver:
-    image:
-      repository: bitnamilegacy/acmesolver
-webhook:
-  image:
-    repository: bitnamilegacy/cert-manager-webhook
-cainjector:
-  image:
-    repository: bitnamilegacy/cainjector
+strategy:
+  type: RollingUpdate
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 1


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

- [x] Chore

## Linked tickets

SQNC-195

## High level description

This PR swaps the [bitnami/cert-manager](https://github.com/bitnami/charts/tree/main/bitnami/cert-manager) chart for [cert-manager/cert-manager](https://github.com/cert-manager/cert-manager/tree/master/deploy/charts/cert-manager) within the SQNC production environment.

## Detailed description

Over the last year, Bitnami has been planning to discontinue its release of container images based on its Helm chart catalogue. That switch-over from a public and free-to-use repository to a legacy one is due to be completed by the end of September 2025. To continue to receive security updates and features, we'll need to switch from Bitnami to another provider. In this case, cert-manager maintains its own chart, which vastly simplifies the switch.