### PR TITLE
Enable auto-merging within Renovate config

### DIFF
--- a/.github/workflows/validate-kind.yaml
+++ b/.github/workflows/validate-kind.yaml
@@ -44,7 +44,10 @@ jobs:
         run: |
           git config user.name ${GITHUB_ACTOR}
           git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
-      - name: Create source and kustomization on main
+      - name: Create surrogate branch
+        run: |
+          git checkout -b "kind/${GITHUB_HEAD_REF}"
+      - name: Create source and kustomization
         if: success()
         run: |
           flux create source git flux-system \
@@ -64,26 +67,33 @@ jobs:
       - name: Patch GitOps branch to match PR
         if: success()
         run: |
-          patch=${GITHUB_HEAD_REF}
-          git fetch origin "${patch}:${patch}"
-          git checkout "${patch}"
-          sed -i -r "s#(branch:).*#\1 $patch#" \
+          surrogate="kind/${GITHUB_HEAD_REF}"
+          echo "${surrogate}"
+          sed -i -r "s#(branch:).*#\1 $surrogate#" \
             ./clusters/kind-cluster/base/flux-system/gotk-sync.yaml
           git add ./clusters/kind-cluster/base/flux-system/gotk-sync.yaml
           git commit -am "Patch GitOps branch to match PR"
-          git push -u origin $patch
+          git push -u origin $surrogate
       - name: Reconcile the update
         if: success()
         run: |
+          surrogate="kind/${GITHUB_HEAD_REF}"
           flux suspend kustomization --all
           flux create source git flux-system \
           --url=${{ github.event.repository.html_url }} \
-          --branch=${GITHUB_HEAD_REF} \
+          --branch=${surrogate} \
           --username=${GITHUB_ACTOR} \
           --password=${{ secrets.GITHUB_TOKEN }}
           flux resume kustomization --all
-          message=$(echo ${GITHUB_HEAD_REF}"@sha1:"$(git log -n 1 ${GITHUB_HEAD_REF} --pretty=format:"%H"))
-          kubectl wait kustomization --all --all-namespaces --for='jsonpath={.status.conditions[?(@.type=="Ready")].message}=Applied revision: '"$message" --timeout=10m
+          message=$(echo ${surrogate}"@sha1:"$(git log -n 1 ${surrogate} --pretty=format:"%H"))
+          sets=$(kubectl get kustomizations -A -o jsonpath='{range .items[*]}{@.metadata.namespace}{"#"}{@.metadata.name}{"#"}{@.spec.sourceRef.name}{"\n"}{end}')
+          ignore_pattern="monitoring-flux-infra"
+          local_sets=$(echo "${sets}" | grep -v $ignore_pattern)
+          for set in $local_sets; do
+            ns=$(echo ${set} | cut -d "#" -f 1)
+            k=$(echo ${set} | cut -d "#" -f 2)
+            kubectl wait kustomization "${k}" -n "${ns}" --for='jsonpath={.status.conditions[?(@.type=="Ready")].message}=Applied revision: '"$message" --timeout=10m
+          done
           kubectl get kustomizations -A
           kubectl wait helmrelease --all --all-namespaces --for=condition=ready --timeout=10m
           kubectl get helmreleases -A
@@ -109,43 +119,6 @@ jobs:
               done
             fi
           done
-      - name: Return GitOps branch to main
-        if: success()
-        run: |
-          sed -i -r "s#(branch:).*#\1 main#" \
-            ./clusters/kind-cluster/base/flux-system/gotk-sync.yaml
-          git add ./clusters/kind-cluster/base/flux-system/gotk-sync.yaml
-          git commit -am "Return GitOps branch to main"
-          git push -u origin ${GITHUB_HEAD_REF} && \
-          gh api --method POST -H "Accept: application/vnd.github+json" \
-            /repos/${{ github.repository }}/check-runs \
-            -f name="gotk-sync.yaml status check" \
-            -f head_sha=$(git log -n 1 ${GITHUB_HEAD_REF} --pretty=format:"%H") \
-            -f status="completed" \
-            -f conclusion="success"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Auto-merge PR into main
-        if: success()
-        run: |
-          echo "GitHub event: ${{ github.event_name }}"
-          if [[ "${{ github.event_name }}" != "pull_request" ]]; then
-            echo "Not a pull request event. Skipping auto-merge."
-            exit 0
-          fi
-
-          PR_BRANCH=$(gh pr view --json headRefName -q .headRefName)
-          echo "PR branch is $PR_BRANCH"
-
-          if [[ "$PR_BRANCH" == renovate/* ]]; then
-            PR_NUMBER=$(gh pr view --json number -q .number)
-            echo "Merging Renovate PR #$PR_NUMBER into main"
-            gh pr merge $PR_NUMBER --squash --admin --delete-branch
-          else
-            echo "PR is not from a Renovate branch. Skipping auto-merge."
-          fi
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Describe failing pods
         if: failure()
         run: |
@@ -180,3 +153,10 @@ jobs:
       - name: Report all resources
         if: failure()
         run: flux get all --all-namespaces
+      - name: Return to parent branch and delete the surrogate
+        if: always()
+        run: |
+          parent=$(echo ${GITHUB_HEAD_REF} | sed "s#kind/renovate#renovate#" -)
+          echo "${parent}"
+          git checkout "${parent}" && \
+          git push origin -d "kind/${parent}"

--- a/renovate.config.js
+++ b/renovate.config.js
@@ -44,7 +44,26 @@ module.exports = (config = {}) => {
         schedule: [
           "0 9-17 * * *"
         ]
-      }
+      },
+      {
+        matchManagers: ["flux"],
+        matchFileNames: [
+          "clusters/kind-cluster/**/*.yaml",
+          "clusters/kind-cluster/**/*.yml",
+        ],
+        postUpgradeTasks: {
+          fileFilters: [
+            "clusters/kind-cluster/**/*.yaml",
+            "clusters/kind-cluster/**/*.yml"
+          ]
+        },
+        separateMajorMinor: true,
+        separateMultipleMajor: true,
+        separateMinorPatch: false,
+        groupName: null,
+        automerge: true,
+        addLabels: ["automerge", "kind"],
+      },
     ],
   };
 };


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

- [x] Chore

## Linked tickets

ENG-211

## High level description

These changes are largely borrowed from [veritable-flux-infra](https://github.com/digicatapult/veritable-flux-infra).

## Detailed description

There is an update to the Renovate configuration included here to enable auto-merging for the FluxCD manager. I've confirmed from the logs that the bot is already capturing the contents of YAML files within the `clusters/kind-cluster` directory and ignoring the other clusters, so the changes needed here are the addition of the labels, separation rules for the types of update, and the setting `automerge: true`.

Within the end-to-end workflow, I've removed the auto-merge step that existed as that will in future be handled by Renovate. A temporary surrogate branch serves to minimise the amount of noise within the Renovate PRs, as any additional commits to the working branch (`renovate/`) are liable to interrupt the bot from processing the request further. We push updates to the gotk-sync.yaml file on the surrogate branch and then have Flux reconcile against that, rather than against the branch originally created by the bot. It's an ephemeral process, so it's safe to then delete this surrogate branch in the final step, again without the original branch being affected.

## Additional context

In the `ignore_pattern` variable in `.github/workflows/validate-kind.yaml`, we should expect to include a string of patterns (delimited by `|`) for Grep to use to exclude any extra GitRepository resources added at a later date. Veritable is already using the [monitoring-flux-infra](https://github.com/digicatapult/monitoring-flux-infra) stack, and I've excluded it here to ensure that this workflow won't break when we do add it to sqnc-flux-infra.

If we change the name of the GitRepository for the external monitoring stack, then the `ignore_pattern` value will need updating to exclude the new name.