### PR TITLE
Add cloudnative-pg CRDs to production

### DIFF
--- a/clusters/l3-sqnc/base/app-sync.yaml
+++ b/clusters/l3-sqnc/base/app-sync.yaml
@@ -95,12 +95,29 @@ spec:
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
+  name: cloudnative-pg-sync
+  namespace: cloudnative-pg
+spec:
+  interval: 1m
+  path: ./clusters/l3-sqnc/cloudnative-pg
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
   name: keycloak-sync
   namespace: keycloak
 spec:
   interval: 1m
   path: ./clusters/l3-sqnc/keycloak 
   prune: true
+  dependsOn:
+    - name: cloudnative-pg-sync
+      namespace: cloudnative-pg
   sourceRef:
     kind: GitRepository
     name: flux-system

--- a/clusters/l3-sqnc/base/flux-system/gotk-sync.yaml
+++ b/clusters/l3-sqnc/base/flux-system/gotk-sync.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: main
+    branch: chore/add_cloudnative_operator_to_production
   url: https://github.com/digicatapult/sqnc-flux-infra.git
 
 ---

--- a/clusters/l3-sqnc/base/flux-system/gotk-sync.yaml
+++ b/clusters/l3-sqnc/base/flux-system/gotk-sync.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: chore/add_cloudnative_operator_to_production
+    branch: main
   url: https://github.com/digicatapult/sqnc-flux-infra.git
 
 ---

--- a/clusters/l3-sqnc/base/namespaces.yaml
+++ b/clusters/l3-sqnc/base/namespaces.yaml
@@ -45,4 +45,12 @@ metadata:
   labels:
     app.kubernetes.io/instance: sqnc
     app.kubernetes.io/version: latest
+  name: cloudnative-pg
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    app.kubernetes.io/instance: sqnc
+    app.kubernetes.io/version: latest
   name: keycloak

--- a/clusters/l3-sqnc/cloudnative-pg/kustomization-config.yaml
+++ b/clusters/l3-sqnc/cloudnative-pg/kustomization-config.yaml
@@ -1,0 +1,7 @@
+---
+nameReference:
+  - kind: ConfigMap
+    version: v1
+    fieldSpecs:
+      - path: spec/valuesFrom/name
+        kind: HelmRelease

--- a/clusters/l3-sqnc/cloudnative-pg/kustomization.yaml
+++ b/clusters/l3-sqnc/cloudnative-pg/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: cloudnative-pg
+resources:
+  - source.yaml
+  - release.yaml
+configMapGenerator:
+  - name: cloudnative-pg-values
+    files:
+      - values.yaml=values.yaml
+configurations:
+  - kustomization-config.yaml
+generatorOptions:
+  disableNameSuffixHash: true

--- a/clusters/l3-sqnc/cloudnative-pg/release.yaml
+++ b/clusters/l3-sqnc/cloudnative-pg/release.yaml
@@ -1,0 +1,25 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
+kind: HelmRelease
+metadata:
+  name: cloudnative-pg
+  namespace: cloudnative-pg
+spec:
+  install:
+    remediation:
+      retries: -1
+  upgrade:
+    remediation:
+      retries: -1
+  releaseName: cloudnative-pg
+  chart:
+    spec:
+      chart: cloudnative-pg
+      sourceRef:
+        kind: HelmRepository
+        name: cloudnative-pg
+      version: "0.26.0"
+  interval: 10m0s
+  valuesFrom:
+    - kind: ConfigMap
+      name: cloudnative-pg-values
+      valuesKey: values.yaml

--- a/clusters/l3-sqnc/cloudnative-pg/source.yaml
+++ b/clusters/l3-sqnc/cloudnative-pg/source.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: cloudnative-pg
+  namespace: cloudnative-pg
+spec:
+  interval: 10m
+  url: https://cloudnative-pg.github.io/charts

--- a/clusters/l3-sqnc/cloudnative-pg/values.yaml
+++ b/clusters/l3-sqnc/cloudnative-pg/values.yaml
@@ -1,0 +1,3 @@
+# https://github.com/cloudnative-pg/charts/blob/main/charts/cloudnative-pg/values.yaml
+crds:
+  create: true


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

- [x] Chore

## Linked tickets

SQNC-196

## High-level description

These changes mirror the use of cloudnative-pg CRDs in staging.

## Detailed description

This request is to add the cloudnative-pg (CNPG) operator to Sequence's production environment and adjust the Keycloak kustomization, so that the latter is dependent on the former being installed first. That operator will be installing with a set of CRDs for wrangling PostgreSQL clusters and databases. With CNPG, we'll be able to rely on database containers from an alternative image repository to [hub.docker.com/u/bitnamilegacy](https://hub.docker.com/u/bitnamilegacy), which we're currently dependent on for Keycloak, both for Keycloak images and for PostgreSQL (via a [bitnami/keycloak](https://github.com/bitnami/charts/tree/main/bitnami/keycloak) subchart).