### PR TITLE
Replace Bitnami chart with codecentric/keycloakx

### DIFF
--- a/clusters/l3-sqnc/base/flux-system/gotk-sync.yaml
+++ b/clusters/l3-sqnc/base/flux-system/gotk-sync.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: chore/add_cloudnative_cluster_to_production
+    branch: main
   url: https://github.com/digicatapult/sqnc-flux-infra.git
 
 ---

--- a/clusters/l3-sqnc/base/flux-system/gotk-sync.yaml
+++ b/clusters/l3-sqnc/base/flux-system/gotk-sync.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: main
+    branch: chore/add_cloudnative_cluster_to_production
   url: https://github.com/digicatapult/sqnc-flux-infra.git
 
 ---

--- a/clusters/l3-sqnc/capacity/attachment-api/values.yaml
+++ b/clusters/l3-sqnc/capacity/attachment-api/values.yaml
@@ -11,7 +11,7 @@ externalSqncIdentity:
 auth:
   clientId: 'l3'
   publicIdpOrigin: "https://auth.dsch-l3.com"
-  internalIdpOrigin: "http://keycloak.keycloak.svc.cluster.local"
+  internalIdpOrigin: "http://keycloak-http.keycloak.svc.cluster.local"
   idpPathPrefix: ""
   oauth2Realm: capacity
   internalRealm: capacity-internal

--- a/clusters/l3-sqnc/capacity/identity-service/values.yaml
+++ b/clusters/l3-sqnc/capacity/identity-service/values.yaml
@@ -6,7 +6,7 @@ externalSqncNode:
 auth:
   clientId: 'l3'
   publicIdpOrigin: "https://auth.dsch-l3.com"
-  internalIdpOrigin: "http://keycloak.keycloak.svc.cluster.local"
+  internalIdpOrigin: "http://keycloak-http.keycloak.svc.cluster.local"
   idpPathPrefix: ""
   oauth2Realm: capacity
   internalRealm: capacity-internal

--- a/clusters/l3-sqnc/capacity/matchmaker-api/values.yaml
+++ b/clusters/l3-sqnc/capacity/matchmaker-api/values.yaml
@@ -14,7 +14,7 @@ externalSqncAttachment:
 auth:
   clientId: 'l3'
   publicIdpOrigin: "https://auth.dsch-l3.com"
-  internalIdpOrigin: "http://keycloak.keycloak.svc.cluster.local"
+  internalIdpOrigin: "http://keycloak-http.keycloak.svc.cluster.local"
   idpPathPrefix: ""
   oauth2Realm: capacity
   internalRealm: capacity-internal

--- a/clusters/l3-sqnc/keycloak/cloudnative-pg/cluster.yaml
+++ b/clusters/l3-sqnc/keycloak/cloudnative-pg/cluster.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: keycloak-cnpg
+  namespace: keycloak
+spec:
+  imageName: ghcr.io/cloudnative-pg/postgresql:17.4
+  instances: 1
+  storage:
+    size: 5Gi
+    storageClass: managed-csi-premium
+  enableSuperuserAccess: true
+  superuserSecret:
+    name: keycloak-cnpg-superuser-creds
+  bootstrap:
+    initdb:
+      database: keycloak
+      owner: keycloak
+      secret:
+        name: keycloak-cnpg-creds
+      import:
+        type: microservice
+        databases:
+          - bitnami_keycloak
+        source:
+          externalCluster: keycloak-bitnami
+  externalClusters:
+    - name: keycloak-bitnami
+      connectionParameters:
+        host: keycloak-postgresql.keycloak.svc.cluster.local
+        port: "5432"
+        user: postgres
+        dbname: postgres
+      password:
+        name: keycloak-external-creds
+        key: password

--- a/clusters/l3-sqnc/keycloak/cloudnative-pg/kustomization.yaml
+++ b/clusters/l3-sqnc/keycloak/cloudnative-pg/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - cluster.yaml

--- a/clusters/l3-sqnc/keycloak/keycloak/release.yaml
+++ b/clusters/l3-sqnc/keycloak/keycloak/release.yaml
@@ -7,28 +7,21 @@ spec:
   install:
     remediation:
       retries: -1
+  upgrade:
+    remediation:
+      retries: -1
   releaseName: keycloak
   chart:
     spec:
-      version: 24.6.7
-      chart: keycloak
+      chart: keycloakx
       sourceRef:
         kind: HelmRepository
-        name: bitnami-oci
+        name: codecentric
+      version: "7.1.3"
   interval: 10m0s
   # Default values
-  # https://github.com/bitnami/charts/blob/master/bitnami/keycloak/values.yaml
+  # https://github.com/codecentric/helm-charts/blob/master/charts/keycloakx/values.yaml
   valuesFrom:
     - kind: ConfigMap
       name: keycloak-values
       valuesKey: keycloak-values.yaml
-    - kind: Secret
-      name: keycloak-postgres-password
-      valuesKey: password
-      targetPath: postgresql.auth.password
-    - kind: Secret
-      name: keycloak-admin-creds
-      valuesKey: password
-      targetPath: auth.adminPassword
-
-

--- a/clusters/l3-sqnc/keycloak/keycloak/values.yaml
+++ b/clusters/l3-sqnc/keycloak/keycloak/values.yaml
@@ -42,7 +42,7 @@ externalDatabase:
   port: 5432
   database: keycloak
   user: keycloak
-  existingSecret: keycloak-cnpg-superuser-creds
+  existingSecret: keycloak-cnpg-creds
   existingSecretPasswordKey: password
 postgresql:
   enabled: false

--- a/clusters/l3-sqnc/keycloak/keycloak/values.yaml
+++ b/clusters/l3-sqnc/keycloak/keycloak/values.yaml
@@ -5,6 +5,7 @@ global:
     allowInsecureImages: true
 image:
   repository: bitnamilegacy/keycloak
+replicas: 0
 keycloakConfigCli:
   image:
     repository: bitnamilegacy/keycloak-config-cli

--- a/clusters/l3-sqnc/keycloak/keycloak/values.yaml
+++ b/clusters/l3-sqnc/keycloak/keycloak/values.yaml
@@ -37,31 +37,14 @@ metrics:
       - action: replace
         sourceLabels: [namespace]
         targetLabel: kubernetes_namespace
+externalDatabase:
+  host: keycloak-cnpg-rw.keycloak.svc.cluster.local
+  port: 5432
+  database: keycloak
+  user: keycloak
+  existingSecret: keycloak-cnpg-superuser-creds
+  existingSecretPasswordKey: password
 postgresql:
-  image:
-    repository: bitnamilegacy/postgresql
-  volumePermissions:
-    image:
-      repository: bitnamilegacy/os-shell
-  global:
-    security:
-      allowInsecureImages: true
-    imagePullSecrets:
-      - name: dockerhub
-  primary:
-    persistence:
-      storageClass: managed-csi-premium
-      size: 5Gi
-  metrics:
-    image:
-      repository: bitnamilegacy/postgres-exporter
-    enabled: true
-  serviceMonitor:
-    enabled: true
-    namespace: keycloak
-    relabelings:
-      - action: replace
-        sourceLabels: [namespace]
-        targetLabel: kubernetes_namespace
+  enabled: false
 podAnnotations:
     instrumentation.opentelemetry.io/inject-java: "monitoring/java-instrumentation"

--- a/clusters/l3-sqnc/keycloak/keycloak/values.yaml
+++ b/clusters/l3-sqnc/keycloak/keycloak/values.yaml
@@ -1,50 +1,55 @@
-global:
-  imagePullSecrets:
-    - name: dockerhub
-  security:
-    allowInsecureImages: true
-image:
-  repository: bitnamilegacy/keycloak
-replicas: 0
-keycloakConfigCli:
-  image:
-    repository: bitnamilegacy/keycloak-config-cli
-production: true
-proxyHeaders: forwarded
+# https://github.com/codecentric/helm-charts/blob/master/charts/keycloakx/values.yaml
+nameOverride: "keycloak"
+proxy:
+  enabled: true
+  mode: forwarded
 ingress:
   enabled: true
   ingressClassName: nginx-keycloak
-  hostname: auth.dsch-l3.com
-adminIngress:
-  enabled: true
-  ingressClassName: nginx-keycloak
-  hostname: auth.dsch-l3.com
-auth:
-  adminUser: "admin"
-extraEnvVars:
+  rules:
+    - host: auth.dsch-l3.com
+      paths:
+        - path: "/"
+          pathType: Prefix
+http:
+  relativePath: "/"
+extraEnv: |
+  - name: KC_BOOTSTRAP_ADMIN_USERNAME
+    value: admin
+  - name: KC_BOOTSTRAP_ADMIN_PASSWORD
+    valueFrom:
+      secretKeyRef:
+        name: keycloak-admin-creds
+        key: password
   - name: KC_HOSTNAME_ADMIN
     value: "https://auth.dsch-l3.com/"
   - name: KC_HOSTNAME
     value: "https://auth.dsch-l3.com/"
   - name: KC_HOSTNAME_DEBUG
     value: "true"
+  - name: JAVA_OPTS_APPEND
+    value: >-
+      -Djgroups.dns.query={{ include "keycloak.fullname" . }}-headless
+command:
+  - "/opt/keycloak/bin/kc.sh"
+  - "--verbose"
+  - "start"
 metrics:
   enabled: true
-  serviceMonitor:
-    enabled: true
-    namespace: keycloak
-    relabelings:
-      - action: replace
-        sourceLabels: [namespace]
-        targetLabel: kubernetes_namespace
-externalDatabase:
-  host: keycloak-cnpg-rw.keycloak.svc.cluster.local
+serviceMonitor:
+  enabled: true
+  namespace: keycloak
+  relabelings:
+    - action: replace
+      sourceLabels: [namespace]
+      targetLabel: kubernetes_namespace
+database:
+  existingSecret: keycloak-cnpg-creds
+  existingSecretKey: password
+  vendor: postgres
+  hostname: keycloak-cnpg-rw.keycloak.svc.cluster.local
   port: 5432
   database: keycloak
-  user: keycloak
-  existingSecret: keycloak-cnpg-creds
-  existingSecretPasswordKey: password
-postgresql:
-  enabled: false
+  username: keycloak
 podAnnotations:
     instrumentation.opentelemetry.io/inject-java: "monitoring/java-instrumentation"

--- a/clusters/l3-sqnc/keycloak/kustomization.yaml
+++ b/clusters/l3-sqnc/keycloak/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: keycloak
 resources:
+  - cloudnative-pg
   - keycloak
   - nginx
   - source.yaml

--- a/clusters/l3-sqnc/keycloak/source.yaml
+++ b/clusters/l3-sqnc/keycloak/source.yaml
@@ -16,3 +16,12 @@ spec:
   type: "oci"
   interval: 10m
   url: oci://registry-1.docker.io/bitnamicharts
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: codecentric
+  namespace: keycloak
+spec:
+  interval: 10m
+  url: https://codecentric.github.io/helm-charts

--- a/clusters/l3-sqnc/optimiser/attachment-api/values.yaml
+++ b/clusters/l3-sqnc/optimiser/attachment-api/values.yaml
@@ -11,7 +11,7 @@ externalSqncIdentity:
 auth:
   clientId: 'l3'
   publicIdpOrigin: "https://auth.dsch-l3.com"
-  internalIdpOrigin: "http://keycloak.keycloak.svc.cluster.local"
+  internalIdpOrigin: "http://keycloak-http.keycloak.svc.cluster.local"
   idpPathPrefix: ""
   oauth2Realm: optimiser
   internalRealm: optimiser-internal

--- a/clusters/l3-sqnc/optimiser/identity-service/values.yaml
+++ b/clusters/l3-sqnc/optimiser/identity-service/values.yaml
@@ -6,7 +6,7 @@ externalSqncNode:
 auth:
   clientId: 'l3'
   publicIdpOrigin: "https://auth.dsch-l3.com"
-  internalIdpOrigin: "http://keycloak.keycloak.svc.cluster.local"
+  internalIdpOrigin: "http://keycloak-http.keycloak.svc.cluster.local"
   idpPathPrefix: ""
   oauth2Realm: optimiser
   internalRealm: optimiser-internal

--- a/clusters/l3-sqnc/optimiser/matchmaker-api/values.yaml
+++ b/clusters/l3-sqnc/optimiser/matchmaker-api/values.yaml
@@ -14,7 +14,7 @@ externalSqncAttachment:
 auth:
   clientId: 'l3'
   publicIdpOrigin: "https://auth.dsch-l3.com"
-  internalIdpOrigin: "http://keycloak.keycloak.svc.cluster.local"
+  internalIdpOrigin: "http://keycloak-http.keycloak.svc.cluster.local"
   idpPathPrefix: ""
   oauth2Realm: optimiser
   internalRealm: optimiser-internal

--- a/clusters/l3-sqnc/order/attachment-api/values.yaml
+++ b/clusters/l3-sqnc/order/attachment-api/values.yaml
@@ -11,7 +11,7 @@ externalSqncIdentity:
 auth:
   clientId: 'l3'
   publicIdpOrigin: "https://auth.dsch-l3.com"
-  internalIdpOrigin: "http://keycloak.keycloak.svc.cluster.local"
+  internalIdpOrigin: "http://keycloak-http.keycloak.svc.cluster.local"
   idpPathPrefix: ""
   oauth2Realm: order
   internalRealm: order-internal

--- a/clusters/l3-sqnc/order/identity-service/values.yaml
+++ b/clusters/l3-sqnc/order/identity-service/values.yaml
@@ -6,7 +6,7 @@ externalSqncNode:
 auth:
   clientId: 'l3'
   publicIdpOrigin: "https://auth.dsch-l3.com"
-  internalIdpOrigin: "http://keycloak.keycloak.svc.cluster.local"
+  internalIdpOrigin: "http://keycloak-http.keycloak.svc.cluster.local"
   idpPathPrefix: ""
   oauth2Realm: order
   internalRealm: order-internal

--- a/clusters/l3-sqnc/order/matchmaker-api/values.yaml
+++ b/clusters/l3-sqnc/order/matchmaker-api/values.yaml
@@ -14,7 +14,7 @@ externalSqncAttachment:
 auth:
   clientId: 'l3'
   publicIdpOrigin: "https://auth.dsch-l3.com"
-  internalIdpOrigin: "http://keycloak.keycloak.svc.cluster.local"
+  internalIdpOrigin: "http://keycloak-http.keycloak.svc.cluster.local"
   idpPathPrefix: ""
   oauth2Realm: order
   internalRealm: order-internal

--- a/clusters/l3-sqnc/secrets/keycloak-cnpg-creds.yaml
+++ b/clusters/l3-sqnc/secrets/keycloak-cnpg-creds.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+data:
+    password: ENC[AES256_GCM,data:x1VeZxZlRNZV5PGIU4QGFOkWdUOO3Vv2,iv:lYrun3JOyT0wpMEOA6bPDKVGYsxCHOUHUwczE0VNySQ=,tag:ue2n56zQkpSgx1zAwSY7EA==,type:str]
+    username: ENC[AES256_GCM,data:CxVJlohsgbECUS4M,iv:WlahRKOUcBVPBzsCCAvn482xwHd17IULHeLeRb/+TDc=,tag:Id5/MWNQ6bjeXiueKB844Q==,type:str]
+kind: Secret
+metadata:
+    creationTimestamp: null
+    name: keycloak-cnpg-creds
+    namespace: keycloak
+    labels:
+        cnpg.io/reload: "true"
+sops:
+    lastmodified: "2025-09-22T08:59:35Z"
+    mac: ENC[AES256_GCM,data:1BWaYlRMHAmRCIKeaUogu13MO7IeJZstTUGxTAxy5sKPEfdLoMu38FkJAjBAHt7nyEdSxlvXA83XpNEEHm3MK7kNdXzeByGBal9bNRsaH6jzxLuUTCigNk56E/bo3/a9hPTobYFYtD1QLlv8tgY2tEzr2KQC1duePxwKK0SmZW0=,iv:mipfvkc36kjVFeRGTt3UM8fk5WEyNVVMSZ1Uin9Jzjg=,tag:HA8DE88kZbxIXgBuUtGk6g==,type:str]
+    pgp:
+        - created_at: "2025-09-22T08:59:35Z"
+          enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            hF4DWK9rONmXZEsSAQdAEu/RhcxRlINDBOCsq4YPIK8p84gsv7wiRzjErsLk8Tgw
+            ToFDqWbjg+VRssRq5GH73itb0tdZbXOlLplN9nvO7m1PAzBunmy+Ys4QJufLSR4R
+            1GgBCQIQIgSF6DvG1hbXA3aGu26o4r8Oh1vNXsjGQFR9Z7DCD3jCJ1UzuLANLnPa
+            JOyHqkTLeJfFhvs7EOdFWwS/e11wbPRLxre14VPPSr01mBVEWvoOnZm2bHXmmDJr
+            1XOwUuFAeTeLqA==
+            =Ud0v
+            -----END PGP MESSAGE-----
+          fp: BC3A767578FF432C7414DE6A73A07B99E207F7AF
+    encrypted_regex: ^(data|stringData)$
+    version: 3.10.2

--- a/clusters/l3-sqnc/secrets/keycloak-cnpg-creds.yaml
+++ b/clusters/l3-sqnc/secrets/keycloak-cnpg-creds.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
-    password: ENC[AES256_GCM,data:x1VeZxZlRNZV5PGIU4QGFOkWdUOO3Vv2,iv:lYrun3JOyT0wpMEOA6bPDKVGYsxCHOUHUwczE0VNySQ=,tag:ue2n56zQkpSgx1zAwSY7EA==,type:str]
-    username: ENC[AES256_GCM,data:CxVJlohsgbECUS4M,iv:WlahRKOUcBVPBzsCCAvn482xwHd17IULHeLeRb/+TDc=,tag:Id5/MWNQ6bjeXiueKB844Q==,type:str]
+    password: ENC[AES256_GCM,data:aVcmBJlvaQ+VGshqmxngEA==,iv:7T7Qjn+cBk2s8gHFJLsLYdOJc1FmIGbB4cZZ/LKyrNc=,tag:/AY3gQFlqw5rh1khrAiIbw==,type:str]
+    username: ENC[AES256_GCM,data:FZaLtoh3xHEu/tzr,iv:k6Uqi0bka311lVycyRFI5kIxT/mb2hQsrKjrc6x8vgs=,tag:4Z9Ax4aJRDjs3qNjcPUlsg==,type:str]
 kind: Secret
 metadata:
     creationTimestamp: null
@@ -10,19 +10,19 @@ metadata:
     labels:
         cnpg.io/reload: "true"
 sops:
-    lastmodified: "2025-09-22T08:59:35Z"
-    mac: ENC[AES256_GCM,data:1BWaYlRMHAmRCIKeaUogu13MO7IeJZstTUGxTAxy5sKPEfdLoMu38FkJAjBAHt7nyEdSxlvXA83XpNEEHm3MK7kNdXzeByGBal9bNRsaH6jzxLuUTCigNk56E/bo3/a9hPTobYFYtD1QLlv8tgY2tEzr2KQC1duePxwKK0SmZW0=,iv:mipfvkc36kjVFeRGTt3UM8fk5WEyNVVMSZ1Uin9Jzjg=,tag:HA8DE88kZbxIXgBuUtGk6g==,type:str]
+    lastmodified: "2025-09-23T12:02:00Z"
+    mac: ENC[AES256_GCM,data:innKvJjXknVxZJ/huWV4qJYz9jD4DgHpV/oEmkVNSYZ8RDkdt/Tws/zxrA7Itb9PLYFVEaEht0i2CMy8GMOx4HP5ekQaXBtbLjfFexOtveZz9nQHvQroCH7xvn2kDTsYmH+BswVOX7LCRilnQcEjysiJBSmXvvybOV/BxpjPMkA=,iv:R6HOECcCvGMrfJtbjFPquqyQ5AImzyKehP78VtnX+R0=,tag:dponHVKLL+2zvG7jdzK01Q==,type:str]
     pgp:
-        - created_at: "2025-09-22T08:59:35Z"
+        - created_at: "2025-09-23T12:02:00Z"
           enc: |-
             -----BEGIN PGP MESSAGE-----
 
-            hF4DWK9rONmXZEsSAQdAEu/RhcxRlINDBOCsq4YPIK8p84gsv7wiRzjErsLk8Tgw
-            ToFDqWbjg+VRssRq5GH73itb0tdZbXOlLplN9nvO7m1PAzBunmy+Ys4QJufLSR4R
-            1GgBCQIQIgSF6DvG1hbXA3aGu26o4r8Oh1vNXsjGQFR9Z7DCD3jCJ1UzuLANLnPa
-            JOyHqkTLeJfFhvs7EOdFWwS/e11wbPRLxre14VPPSr01mBVEWvoOnZm2bHXmmDJr
-            1XOwUuFAeTeLqA==
-            =Ud0v
+            hF4DWK9rONmXZEsSAQdAmXcHgKZtENtOAuFTa8OubQBggcHUaG8oe9TPQYL+1Tgw
+            yMv46jK+ELfOT38CCp9YMe0ghX7e4wUsnYA8geeWlTi4hyHvBBeoVcLFSO4jY88H
+            1GgBCQIQ+kj/s2GavZjRafkSMIk7JSwpGf2tq0IrPPFd1co/EXxOUoJPsA7l8uZ9
+            QXkLXnynuKPDWZDvL6VMV4nTwK0KxCevVUDqWOpvP9IeVAb0W1kwSzl4Ms4yCgLI
+            BzT3++SUn896Ug==
+            =7ckN
             -----END PGP MESSAGE-----
           fp: BC3A767578FF432C7414DE6A73A07B99E207F7AF
     encrypted_regex: ^(data|stringData)$

--- a/clusters/l3-sqnc/secrets/keycloak-cnpg-superuser-creds.yaml
+++ b/clusters/l3-sqnc/secrets/keycloak-cnpg-superuser-creds.yaml
@@ -1,6 +1,7 @@
 apiVersion: v1
 data:
-    password: ENC[AES256_GCM,data:IjkgPr8NKcoqunSchGLbQg==,iv:URLc4iw5Vl6qfNYUj84gd5vM/fyV8HWX3S9hNreiA/c=,tag:seLfyqCXNF6UDd0XlIsTCw==,type:str]
+    password: ENC[AES256_GCM,data:h6/HQHTzoEBGwHvJNGPI1w==,iv:py0fgMlJXXYSaaq66aHgCNPlbvBB2+Ej0ymG7mnyOng=,tag:eStAK3KfXQh/f9WDi4NGxw==,type:str]
+    username: ENC[AES256_GCM,data:hirme6Wj007m9kk/,iv:gV0sjM+sQtRy/QtN1vG7T11yvZf1Z11VOY5YUUxxS7w=,tag:xpxL4MKHWaQkZOj7ygIWHg==,type:str]
 kind: Secret
 metadata:
     creationTimestamp: null
@@ -9,19 +10,19 @@ metadata:
     labels:
         cnpg.io/reload: "true"
 sops:
-    lastmodified: "2025-09-22T08:59:35Z"
-    mac: ENC[AES256_GCM,data:iWwR/WK0FNiTQ4LlO635lM/v+4tRpY7nu5yfuQnkigxuMlnzFOfRKbSFU2d60G3Cu/3BotI9J+JjArvkVkmLrFnOvDC3/82f7xOx55mfadorxxH9E7PdoaCGvlRPxyDQ6O+EIG+HKxKGXH4lntAseDz8rgSvvZTaMtz2PIMNTDA=,iv:6Y0cvyo6PkMyUxwahf3dqgMaiJ5ENwNlfPWaXpDGkvo=,tag:13EbWB6mRkTMRCFIh1rzPA==,type:str]
+    lastmodified: "2025-09-23T10:43:48Z"
+    mac: ENC[AES256_GCM,data:vAE+NfJKFQDtKGaSTfG930yhxz9Q4GpbjoVYLeXna7L69qWlDRwtgbnO8vgGCZSCGEXpwPoDSiOHMqSqCfbIaT8ocJJCibXIsJyEgFHHC1zFs0SxCT+LAdtXGOXiOl1CARuMf6euXVhjEJVYgbjJtD26WZdy+hUIgfDLljr8Rd8=,iv:Mrd8ldSaiHT7ocP5k0x2itgXEhTu3pN3CU5qV0rK2JE=,tag:O56RVss8UBuWyu11CvGyRw==,type:str]
     pgp:
-        - created_at: "2025-09-22T08:59:35Z"
+        - created_at: "2025-09-23T10:43:48Z"
           enc: |-
             -----BEGIN PGP MESSAGE-----
 
-            hF4DWK9rONmXZEsSAQdAwFLIzmywiCX9o+LWXzKGHHard63c3YnOL76Is1BePnAw
-            /IQJPlEP5grZ5ENy1OzsR45aRmvzWA8/krj3P/jIbY9S8JQQDgSN/wBHO8f5WzYQ
-            1GgBCQIQH9KEOrvLyUnGf/ZpzEpIelnZ+pKLUsBg//xmdHAxxo3aLET2t2RYCgUx
-            spgz62G4PVz3kIGPkE//FZIjvgRwwFIdE6Rnzd0oy3mTvWjSTXl82IHFTzJ3gvNn
-            8YDuNxRlnQ5A9w==
-            =yagt
+            hF4DWK9rONmXZEsSAQdAA2rCWTSL58BemPaEBd77qCIRpk1DtlgTmeVY05YEvH0w
+            +hcaqAVAl4u0AFptO30YLomYdc91C8qhTQ0EzSN2/PFXqt1KxfpcUkbc8AHs8fN9
+            1GYBCQIQwva95GwYp2xg41kuQVp7qsTo6jv5g2g+A5jfChpgX7tot+RfiQrWDqZs
+            7yxnAdMd9joLbDgX+/jFiHU2r3Omt8B0xEDk4mA4tWj2tUcnw2cJi7725RzT4IhG
+            VcqGOxG3AKc=
+            =aDrc
             -----END PGP MESSAGE-----
           fp: BC3A767578FF432C7414DE6A73A07B99E207F7AF
     encrypted_regex: ^(data|stringData)$

--- a/clusters/l3-sqnc/secrets/keycloak-cnpg-superuser-creds.yaml
+++ b/clusters/l3-sqnc/secrets/keycloak-cnpg-superuser-creds.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+data:
+    password: ENC[AES256_GCM,data:IjkgPr8NKcoqunSchGLbQg==,iv:URLc4iw5Vl6qfNYUj84gd5vM/fyV8HWX3S9hNreiA/c=,tag:seLfyqCXNF6UDd0XlIsTCw==,type:str]
+kind: Secret
+metadata:
+    creationTimestamp: null
+    name: keycloak-cnpg-superuser-creds
+    namespace: keycloak
+    labels:
+        cnpg.io/reload: "true"
+sops:
+    lastmodified: "2025-09-22T08:59:35Z"
+    mac: ENC[AES256_GCM,data:iWwR/WK0FNiTQ4LlO635lM/v+4tRpY7nu5yfuQnkigxuMlnzFOfRKbSFU2d60G3Cu/3BotI9J+JjArvkVkmLrFnOvDC3/82f7xOx55mfadorxxH9E7PdoaCGvlRPxyDQ6O+EIG+HKxKGXH4lntAseDz8rgSvvZTaMtz2PIMNTDA=,iv:6Y0cvyo6PkMyUxwahf3dqgMaiJ5ENwNlfPWaXpDGkvo=,tag:13EbWB6mRkTMRCFIh1rzPA==,type:str]
+    pgp:
+        - created_at: "2025-09-22T08:59:35Z"
+          enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            hF4DWK9rONmXZEsSAQdAwFLIzmywiCX9o+LWXzKGHHard63c3YnOL76Is1BePnAw
+            /IQJPlEP5grZ5ENy1OzsR45aRmvzWA8/krj3P/jIbY9S8JQQDgSN/wBHO8f5WzYQ
+            1GgBCQIQH9KEOrvLyUnGf/ZpzEpIelnZ+pKLUsBg//xmdHAxxo3aLET2t2RYCgUx
+            spgz62G4PVz3kIGPkE//FZIjvgRwwFIdE6Rnzd0oy3mTvWjSTXl82IHFTzJ3gvNn
+            8YDuNxRlnQ5A9w==
+            =yagt
+            -----END PGP MESSAGE-----
+          fp: BC3A767578FF432C7414DE6A73A07B99E207F7AF
+    encrypted_regex: ^(data|stringData)$
+    version: 3.10.2

--- a/clusters/l3-sqnc/secrets/keycloak-external-creds.yaml
+++ b/clusters/l3-sqnc/secrets/keycloak-external-creds.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
-    password: ENC[AES256_GCM,data:iPdEnOFxjno7cnOo7uMIws6jr0MBZc0c,iv:T0jHJp0Kg7/BL+E+NWuNr54N8Ifca69lgeBQRhGlHhk=,tag:nYNcpaAUbVUeBMs6HeBVlA==,type:str]
-    username: ENC[AES256_GCM,data:y2WqAepRrwmG2vR6,iv:WDlJ3mygfjj1tCPJYCfUMg+ioUUiYIh6k14QDuIXfNs=,tag:ineoTsn3eLNG8qeuzwp80Q==,type:str]
+    password: ENC[AES256_GCM,data:XW7otjNIk+VhKWjX2oqgMA==,iv:Vs0yucLNzRa7Mer7qaJt09Z1VLVnOLS+idgpjRPofsg=,tag:Ve9Fnuj77tipIuCUFX6pNQ==,type:str]
+    username: ENC[AES256_GCM,data:F/QPXEdVWbfjjtNV,iv:EaTX+9rWTtRiGoV3o1dAkMdWlFnQW7gt8jl/EibNw6Y=,tag:DRtrcEW+QtlA9ZLldW0kYQ==,type:str]
 kind: Secret
 metadata:
     creationTimestamp: null
@@ -10,19 +10,19 @@ metadata:
     labels:
         cnpg.io/reload: "true"
 sops:
-    lastmodified: "2025-09-22T08:59:35Z"
-    mac: ENC[AES256_GCM,data:ZkoMNRdnXCMy0ZlwktzIG1zeID63PlM6H+IDZ0KRBocSc3DaMAfMiG+sMn2ShIfNEuABE+RTKumiFdF3dd9gINK6vW2QAAG2ULPd4VNpv7tt7r1wRIR69fvQEltbn0cIwGRnhRXxGK3IZf7ZI+2I38wJPCBIUl1ekjXRp5CNAQ8=,iv:X4Vm2j1fP1+ZKL4H4evJmohRJ8+rF0ahJ71h2Ijp0OQ=,tag:6tSoW2hOoNmTxYMJigYAsQ==,type:str]
+    lastmodified: "2025-09-23T09:15:51Z"
+    mac: ENC[AES256_GCM,data:d9YK6Yihx/7r8vcO2D+o+IAzEXJeAc7JHTg7IA/+df9dNeDL+VU+VnrGG2hxu/nxPpz9NQCn95Q+l4C5XRMWW/VYUJqGCzAa6P1O5UWrcz83YFj46oTEMP8159zKQ8MMiY1BdliHm+mT4IkPKjoWBfdFFLYi/58vEKUmkAr9+b8=,iv:m2NJSOmmihJU9SN/sA7fCN0C08LkhlvAccvpnvNt+E4=,tag:4AcO+0AuTIV6LIXiQsjSKg==,type:str]
     pgp:
-        - created_at: "2025-09-22T08:59:35Z"
+        - created_at: "2025-09-23T09:15:51Z"
           enc: |-
             -----BEGIN PGP MESSAGE-----
 
-            hF4DWK9rONmXZEsSAQdAhea7lS+FLSeG59x/VEie9uDogPYI5sTftC6SWPAsyFAw
-            tLB4tbbGlGy0jpaI5jPUfBx2uT5ngOhbBsNy4vT70OqMKcZYvpra8kJwbs7jee9B
-            1GgBCQIQ459GYS1AFKg1YMtIF7K8Upqxpp2QU3KGH6bKQn3rK4Fl2tAaLEykrfwO
-            cXOMAFaB/4r7zoKBc93otSDkgmlFbljiJKC8aSnIsyPKjdGi8Je013cuj1zau+5u
-            7PlTOH8iVpbQUQ==
-            =ZOPn
+            hF4DWK9rONmXZEsSAQdAHePrh7lhslzXnM2fSu41KYy+S5pKYuSZZ2bhCDW2ykUw
+            Rt4H3WE0zngH5bTG6PBiCd0Enc+KLYyMVzoGnDX200pBkHz16f39vdZOoExge+YG
+            1GYBCQIQqKbp365PJemvxOodhxXTsuZtu/nBqFMajaS5BlYxgE1DNj4fyaWC4QiT
+            xmjfr68rlbGct4pOD8x0xSYz/AhOD9A9cuLdbDDgjYGUMhBNzgiXrdg3MAmJ2xyo
+            6apLjySuFlw=
+            =f/2l
             -----END PGP MESSAGE-----
           fp: BC3A767578FF432C7414DE6A73A07B99E207F7AF
     encrypted_regex: ^(data|stringData)$

--- a/clusters/l3-sqnc/secrets/keycloak-external-creds.yaml
+++ b/clusters/l3-sqnc/secrets/keycloak-external-creds.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+data:
+    password: ENC[AES256_GCM,data:iPdEnOFxjno7cnOo7uMIws6jr0MBZc0c,iv:T0jHJp0Kg7/BL+E+NWuNr54N8Ifca69lgeBQRhGlHhk=,tag:nYNcpaAUbVUeBMs6HeBVlA==,type:str]
+    username: ENC[AES256_GCM,data:y2WqAepRrwmG2vR6,iv:WDlJ3mygfjj1tCPJYCfUMg+ioUUiYIh6k14QDuIXfNs=,tag:ineoTsn3eLNG8qeuzwp80Q==,type:str]
+kind: Secret
+metadata:
+    creationTimestamp: null
+    name: keycloak-external-creds
+    namespace: keycloak
+    labels:
+        cnpg.io/reload: "true"
+sops:
+    lastmodified: "2025-09-22T08:59:35Z"
+    mac: ENC[AES256_GCM,data:ZkoMNRdnXCMy0ZlwktzIG1zeID63PlM6H+IDZ0KRBocSc3DaMAfMiG+sMn2ShIfNEuABE+RTKumiFdF3dd9gINK6vW2QAAG2ULPd4VNpv7tt7r1wRIR69fvQEltbn0cIwGRnhRXxGK3IZf7ZI+2I38wJPCBIUl1ekjXRp5CNAQ8=,iv:X4Vm2j1fP1+ZKL4H4evJmohRJ8+rF0ahJ71h2Ijp0OQ=,tag:6tSoW2hOoNmTxYMJigYAsQ==,type:str]
+    pgp:
+        - created_at: "2025-09-22T08:59:35Z"
+          enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            hF4DWK9rONmXZEsSAQdAhea7lS+FLSeG59x/VEie9uDogPYI5sTftC6SWPAsyFAw
+            tLB4tbbGlGy0jpaI5jPUfBx2uT5ngOhbBsNy4vT70OqMKcZYvpra8kJwbs7jee9B
+            1GgBCQIQ459GYS1AFKg1YMtIF7K8Upqxpp2QU3KGH6bKQn3rK4Fl2tAaLEykrfwO
+            cXOMAFaB/4r7zoKBc93otSDkgmlFbljiJKC8aSnIsyPKjdGi8Je013cuj1zau+5u
+            7PlTOH8iVpbQUQ==
+            =ZOPn
+            -----END PGP MESSAGE-----
+          fp: BC3A767578FF432C7414DE6A73A07B99E207F7AF
+    encrypted_regex: ^(data|stringData)$
+    version: 3.10.2


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

- [x] Chore
- [x] Breaking Change (fix or feature that would cause existing functionality to change)

## Linked tickets

SQNC-208

## High level description

This ticket is to bootstrap a new cloudnative-pg database for Keycloak using one that exists already (via Bitnami's PostgreSQL sub-chart), and swap the Keycloak providers from Bitnami to CodeCentric. These changes are staggered in a way that ensures that the cluster is functional, that it has the data needed after the bootstrapping, and that additional secrets can be implemented (i.e. corrective actions) before committing to the eventual chart switch.

## Detailed description

This pull request is to create a new CNPG PostgreSQL cluster for Keycloak based on the existing Bitnami PostgreSQL database. Switching providers won't impact the integrity of the data itself; this process has been tried with several other repositories via automated and manual steps. It won't require a major PostgreSQL version at this juncture; both clusters will share the same major semantic version.

## Describe alternatives you've considered

Previously, I'd relied on manually backing up the existing Keycloak namespace, restoring the PVCs, and then installing Keycloak via `helm` so that FluxCD wasn't aware of it. I'd then scale down the new Keycloak replicas and investigate the backed-up database to verify its integrity. That restored database would then be used to manually dump and restore to a new CNPG cluster that had been initialised via FluxCD's controllers. This process has been tried and tested a few times, but it's slow to repeat dozens of times over and over again.