### PR TITLE
Replace Bitnami's NIC chart on staging

### DIFF
--- a/clusters/sqnc-staging/base/flux-system/gotk-sync.yaml
+++ b/clusters/sqnc-staging/base/flux-system/gotk-sync.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: main
+    branch: chore/add_ingress_nginx_chart_to_staging
   url: https://github.com/digicatapult/sqnc-flux-infra.git
 
 ---

--- a/clusters/sqnc-staging/base/flux-system/gotk-sync.yaml
+++ b/clusters/sqnc-staging/base/flux-system/gotk-sync.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: chore/add_ingress_nginx_chart_to_staging
+    branch: main
   url: https://github.com/digicatapult/sqnc-flux-infra.git
 
 ---

--- a/clusters/sqnc-staging/demanda/nginx/release.yaml
+++ b/clusters/sqnc-staging/demanda/nginx/release.yaml
@@ -8,17 +8,20 @@ spec:
   install:
     remediation:
       retries: -1
-  releaseName: nginx-ingress-controller
+  upgrade:
+    remediation:
+      retries: -1
+  releaseName: ingress-nginx
   chart:
     spec:
-      version: 11.6.12
-      chart: nginx-ingress-controller
+      chart: ingress-nginx
       sourceRef:
         kind: HelmRepository
-        name: bitnami-oci
+        name: ingress-nginx
+      version: "4.13.2"
   interval: 10m0s
   # Default values
-  # https://github.com/bitnami/charts/blob/master/bitnami/nginx-ingress-controller/values.yaml
+  # https://github.com/kubernetes/ingress-nginx/blob/main/charts/ingress-nginx/values.yaml
   valuesFrom:
     - kind: ConfigMap
       name: demanda-values

--- a/clusters/sqnc-staging/demanda/nginx/values.yaml
+++ b/clusters/sqnc-staging/demanda/nginx/values.yaml
@@ -1,44 +1,38 @@
-watchIngressWithoutClass: true
-scope:
-  enabled: true
-ingressClassResource:
-  name: nginx-demanda
-  default: false
-service:
-  type: LoadBalancer
-  annotations: 
-    service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path: /healthz
-    external-dns.alpha.kubernetes.io/hostname: demanda.sqnc-stage.com
-    cert-manager.io/cluster-issuer: letsencrypt-prod
-    cert-manager.io/common-name: demanda.sqnc-stage.com
-extraArgs:
-  default-ssl-certificate: "demanda/demanda-sqnc-stage-com-prod-tls"
-nodeSelector:
-  kubernetes.io/os: linux
-tolerations:
-  - effect: NoSchedule
-    key: node-role.kubernetes.io/master
-    operator: Equal
-  - effect: NoSchedule
-    key: node-role.kubernetes.io/control-plane
-    operator: Equal
-containerPorts:
-  http: 80
-  https: 443
-metrics:
-  enabled: true
-  serviceMonitor:
+# https://github.com/kubernetes/ingress-nginx/blob/main/charts/ingress-nginx/values.yaml
+controller:
+  watchIngressWithoutClass: true
+  scope:
     enabled: true
-    namespace: demanda
-    relabelings:
-      - action: replace
-        sourceLabels: [namespace]
-        targetLabel: kubernetes_namespace
-global:
-  security:
-    allowInsecureImages: true
-image:
-  repository: bitnamilegacy/nginx-ingress-controller
-defaultBackend:
-  image:
-    repository: bitnamilegacy/nginx
+  ingressClassResource:
+    name: nginx-demanda
+    default: false
+  service:
+    type: LoadBalancer
+    annotations:
+      service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path: /healthz
+      external-dns.alpha.kubernetes.io/hostname: demanda.sqnc-stage.com
+      cert-manager.io/cluster-issuer: letsencrypt-prod
+      cert-manager.io/common-name: demanda.sqnc-stage.com
+  extraArgs:
+    default-ssl-certificate: "demanda/demanda-sqnc-stage-com-prod-tls"
+  nodeSelector:
+    kubernetes.io/os: linux
+  tolerations:
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/master
+      operator: Equal
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/control-plane
+      operator: Equal
+  containerPort:
+    http: 80
+    https: 443
+  metrics:
+    enabled: true
+    serviceMonitor:
+      enabled: true
+      namespace: demanda
+      relabelings:
+        - action: replace
+          sourceLabels: [namespace]
+          targetLabel: kubernetes_namespace

--- a/clusters/sqnc-staging/demanda/source.yaml
+++ b/clusters/sqnc-staging/demanda/source.yaml
@@ -26,3 +26,12 @@ spec:
   type: "oci"
   interval: 10m
   url: oci://registry-1.docker.io/bitnamicharts
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: ingress-nginx
+  namespace: demanda
+spec:
+  interval: 10m
+  url: https://kubernetes.github.io/ingress-nginx

--- a/clusters/sqnc-staging/demandb/nginx/release.yaml
+++ b/clusters/sqnc-staging/demandb/nginx/release.yaml
@@ -8,17 +8,20 @@ spec:
   install:
     remediation:
       retries: -1
-  releaseName: nginx-ingress-controller
+  upgrade:
+    remediation:
+      retries: -1
+  releaseName: ingress-nginx
   chart:
     spec:
-      version: 11.6.12
-      chart: nginx-ingress-controller
+      chart: ingress-nginx
       sourceRef:
         kind: HelmRepository
-        name: bitnami-oci
+        name: ingress-nginx
+      version: "4.13.2"
   interval: 10m0s
   # Default values
-  # https://github.com/bitnami/charts/blob/master/bitnami/nginx-ingress-controller/values.yaml
+  # https://github.com/kubernetes/ingress-nginx/blob/main/charts/ingress-nginx/values.yaml
   valuesFrom:
     - kind: ConfigMap
       name: demandb-values

--- a/clusters/sqnc-staging/demandb/nginx/values.yaml
+++ b/clusters/sqnc-staging/demandb/nginx/values.yaml
@@ -1,44 +1,38 @@
-watchIngressWithoutClass: true
-scope:
-  enabled: true
-ingressClassResource:
-  name: nginx-demandb
-  default: false
-service:
-  type: LoadBalancer
-  annotations: 
-    service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path: /healthz
-    external-dns.alpha.kubernetes.io/hostname: demandb.sqnc-stage.com
-    cert-manager.io/cluster-issuer: letsencrypt-prod
-    cert-manager.io/common-name: demandb.sqnc-stage.com
-extraArgs:
-  default-ssl-certificate: "demandb/demandb-sqnc-stage-com-prod-tls"
-nodeSelector:
-  kubernetes.io/os: linux
-tolerations:
-  - effect: NoSchedule
-    key: node-role.kubernetes.io/master
-    operator: Equal
-  - effect: NoSchedule
-    key: node-role.kubernetes.io/control-plane
-    operator: Equal
-containerPorts:
-  http: 80
-  https: 443
-metrics:
-  enabled: true
-  serviceMonitor:
+# https://github.com/kubernetes/ingress-nginx/blob/main/charts/ingress-nginx/values.yaml
+controller:
+  watchIngressWithoutClass: true
+  scope:
     enabled: true
-    namespace: demandb
-    relabelings:
-      - action: replace
-        sourceLabels: [namespace]
-        targetLabel: kubernetes_namespace
-global:
-  security:
-    allowInsecureImages: true
-image:
-  repository: bitnamilegacy/nginx-ingress-controller
-defaultBackend:
-  image:
-    repository: bitnamilegacy/nginx
+  ingressClassResource:
+    name: nginx-demandb
+    default: false
+  service:
+    type: LoadBalancer
+    annotations:
+      service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path: /healthz
+      external-dns.alpha.kubernetes.io/hostname: demandb.sqnc-stage.com
+      cert-manager.io/cluster-issuer: letsencrypt-prod
+      cert-manager.io/common-name: demandb.sqnc-stage.com
+  extraArgs:
+    default-ssl-certificate: "demandb/demandb-sqnc-stage-com-prod-tls"
+  nodeSelector:
+    kubernetes.io/os: linux
+  tolerations:
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/master
+      operator: Equal
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/control-plane
+      operator: Equal
+  containerPort:
+    http: 80
+    https: 443
+  metrics:
+    enabled: true
+    serviceMonitor:
+      enabled: true
+      namespace: demandb
+      relabelings:
+        - action: replace
+          sourceLabels: [namespace]
+          targetLabel: kubernetes_namespace

--- a/clusters/sqnc-staging/demandb/source.yaml
+++ b/clusters/sqnc-staging/demandb/source.yaml
@@ -26,3 +26,12 @@ spec:
   type: "oci"
   interval: 10m
   url: oci://registry-1.docker.io/bitnamicharts
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: ingress-nginx
+  namespace: demandb
+spec:
+  interval: 10m
+  url: https://kubernetes.github.io/ingress-nginx

--- a/clusters/sqnc-staging/keycloak/nginx/release.yaml
+++ b/clusters/sqnc-staging/keycloak/nginx/release.yaml
@@ -8,17 +8,20 @@ spec:
   install:
     remediation:
       retries: -1
-  releaseName: nginx-ingress-controller
+  upgrade:
+    remediation:
+      retries: -1
+  releaseName: ingress-nginx
   chart:
     spec:
-      version: 11.6.12
-      chart: nginx-ingress-controller
+      chart: ingress-nginx
       sourceRef:
         kind: HelmRepository
-        name: bitnami-oci
+        name: ingress-nginx
+      version: "4.13.2"
   interval: 10m0s
   # Default values
-  # https://github.com/bitnami/charts/blob/master/bitnami/nginx-ingress-controller/values.yaml
+  # https://github.com/kubernetes/ingress-nginx/blob/main/charts/ingress-nginx/values.yaml
   valuesFrom:
     - kind: ConfigMap
       name: keycloak-values

--- a/clusters/sqnc-staging/keycloak/nginx/values.yaml
+++ b/clusters/sqnc-staging/keycloak/nginx/values.yaml
@@ -1,44 +1,38 @@
-watchIngressWithoutClass: true
-scope:
-  enabled: true
-ingressClassResource:
-  name: nginx-keycloak
-  default: false
-service:
-  type: LoadBalancer
-  annotations: 
-    service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path: /healthz
-    external-dns.alpha.kubernetes.io/hostname: auth.sqnc-stage.com
-    cert-manager.io/cluster-issuer: letsencrypt-prod
-    cert-manager.io/common-name: auth.sqnc-stage.com
-extraArgs:
-  default-ssl-certificate: "keycloak/auth-sqnc-stage-com-prod-tls"
-nodeSelector:
-  kubernetes.io/os: linux
-tolerations:
-  - effect: NoSchedule
-    key: node-role.kubernetes.io/master
-    operator: Equal
-  - effect: NoSchedule
-    key: node-role.kubernetes.io/control-plane
-    operator: Equal
-containerPorts:
-  http: 80
-  https: 443
-metrics:
-  enabled: true
-  serviceMonitor:
+# https://github.com/kubernetes/ingress-nginx/blob/main/charts/ingress-nginx/values.yaml
+controller:
+  watchIngressWithoutClass: true
+  scope:
     enabled: true
-    namespace: keycloak
-    relabelings:
-      - action: replace
-        sourceLabels: [namespace]
-        targetLabel: kubernetes_namespace
-global:
-  security:
-    allowInsecureImages: true
-image:
-  repository: bitnamilegacy/nginx-ingress-controller
-defaultBackend:
-  image:
-    repository: bitnamilegacy/nginx
+  ingressClassResource:
+    name: nginx-keycloak
+    default: false
+  service:
+    type: LoadBalancer
+    annotations:
+      service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path: /healthz
+      external-dns.alpha.kubernetes.io/hostname: auth.sqnc-stage.com
+      cert-manager.io/cluster-issuer: letsencrypt-prod
+      cert-manager.io/common-name: auth.sqnc-stage.com
+  extraArgs:
+    default-ssl-certificate: "keycloak/auth-sqnc-stage-com-prod-tls"
+  nodeSelector:
+    kubernetes.io/os: linux
+  tolerations:
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/master
+      operator: Equal
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/control-plane
+      operator: Equal
+  containerPort:
+    http: 80
+    https: 443
+  metrics:
+    enabled: true
+    serviceMonitor:
+      enabled: true
+      namespace: keycloak
+      relabelings:
+        - action: replace
+          sourceLabels: [namespace]
+          targetLabel: kubernetes_namespace

--- a/clusters/sqnc-staging/keycloak/source.yaml
+++ b/clusters/sqnc-staging/keycloak/source.yaml
@@ -34,3 +34,12 @@ metadata:
 spec:
   interval: 10m
   url: https://codecentric.github.io/helm-charts
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: ingress-nginx
+  namespace: keycloak
+spec:
+  interval: 10m
+  url: https://kubernetes.github.io/ingress-nginx

--- a/clusters/sqnc-staging/match2/nginx/release.yaml
+++ b/clusters/sqnc-staging/match2/nginx/release.yaml
@@ -8,17 +8,20 @@ spec:
   install:
     remediation:
       retries: -1
-  releaseName: nginx-ingress-controller
+  upgrade:
+    remediation:
+      retries: -1
+  releaseName: ingress-nginx
   chart:
     spec:
-      version: 11.6.12
-      chart: nginx-ingress-controller
+      chart: ingress-nginx
       sourceRef:
         kind: HelmRepository
-        name: bitnami-oci
+        name: ingress-nginx
+      version: "4.13.2"
   interval: 10m0s
   # Default values
-  # https://github.com/bitnami/charts/blob/master/bitnami/nginx-ingress-controller/values.yaml
+  # https://github.com/kubernetes/ingress-nginx/blob/main/charts/ingress-nginx/values.yaml
   valuesFrom:
     - kind: ConfigMap
       name: match2-values

--- a/clusters/sqnc-staging/match2/nginx/values.yaml
+++ b/clusters/sqnc-staging/match2/nginx/values.yaml
@@ -1,44 +1,38 @@
-watchIngressWithoutClass: true
-scope:
-  enabled: true
-ingressClassResource:
-  name: nginx-match2
-  default: false
-service:
-  type: LoadBalancer
-  annotations: 
-    service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path: /healthz
-    external-dns.alpha.kubernetes.io/hostname: match2.sqnc-stage.com
-    cert-manager.io/cluster-issuer: letsencrypt-prod
-    cert-manager.io/common-name: match2.sqnc-stage.com
-extraArgs:
-  default-ssl-certificate: "match2/match2-sqnc-stage-com-prod-tls"
-nodeSelector:
-  kubernetes.io/os: linux
-tolerations:
-  - effect: NoSchedule
-    key: node-role.kubernetes.io/master
-    operator: Equal
-  - effect: NoSchedule
-    key: node-role.kubernetes.io/control-plane
-    operator: Equal
-containerPorts:
-  http: 80
-  https: 443
-metrics:
-  enabled: true
-  serviceMonitor:
+# https://github.com/kubernetes/ingress-nginx/blob/main/charts/ingress-nginx/values.yaml
+controller:
+  watchIngressWithoutClass: true
+  scope:
     enabled: true
-    namespace: match2
-    relabelings:
-      - action: replace
-        sourceLabels: [namespace]
-        targetLabel: kubernetes_namespace
-global:
-  security:
-    allowInsecureImages: true
-image:
-  repository: bitnamilegacy/nginx-ingress-controller
-defaultBackend:
-  image:
-    repository: bitnamilegacy/nginx
+  ingressClassResource:
+    name: nginx-match2
+    default: false
+  service:
+    type: LoadBalancer
+    annotations:
+      service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path: /healthz
+      external-dns.alpha.kubernetes.io/hostname: match2.sqnc-stage.com
+      cert-manager.io/cluster-issuer: letsencrypt-prod
+      cert-manager.io/common-name: match2.sqnc-stage.com
+  extraArgs:
+    default-ssl-certificate: "match2/match2-sqnc-stage-com-prod-tls"
+  nodeSelector:
+    kubernetes.io/os: linux
+  tolerations:
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/master
+      operator: Equal
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/control-plane
+      operator: Equal
+  containerPort:
+    http: 80
+    https: 443
+  metrics:
+    enabled: true
+    serviceMonitor:
+      enabled: true
+      namespace: match2
+      relabelings:
+        - action: replace
+          sourceLabels: [namespace]
+          targetLabel: kubernetes_namespace

--- a/clusters/sqnc-staging/match2/source.yaml
+++ b/clusters/sqnc-staging/match2/source.yaml
@@ -26,3 +26,12 @@ spec:
   type: "oci"
   interval: 10m
   url: oci://registry-1.docker.io/bitnamicharts
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: ingress-nginx
+  namespace: match2
+spec:
+  interval: 10m
+  url: https://kubernetes.github.io/ingress-nginx

--- a/clusters/sqnc-staging/monitoring/nginx/release.yaml
+++ b/clusters/sqnc-staging/monitoring/nginx/release.yaml
@@ -8,17 +8,20 @@ spec:
   install:
     remediation:
       retries: -1
-  releaseName: nginx-ingress-controller
+  upgrade:
+    remediation:
+      retries: -1
+  releaseName: ingress-nginx
   chart:
     spec:
-      version: 11.6.12
-      chart: nginx-ingress-controller
+      chart: ingress-nginx
       sourceRef:
         kind: HelmRepository
-        name: bitnami-oci
-  interval: 10m
+        name: ingress-nginx
+      version: "4.13.2"
+  interval: 10m0s
   # Default values
-  # https://github.com/bitnami/charts/blob/master/bitnami/nginx-ingress-controller/values.yaml
+  # https://github.com/kubernetes/ingress-nginx/blob/main/charts/ingress-nginx/values.yaml
   valuesFrom:
     - kind: ConfigMap
       name: monitoring-values

--- a/clusters/sqnc-staging/monitoring/nginx/values.yaml
+++ b/clusters/sqnc-staging/monitoring/nginx/values.yaml
@@ -1,44 +1,37 @@
-watchIngressWithoutClass: true
-scope:
-  enabled: true
-ingressClassResource:
-  name: nginx-monitoring
-  default: false
-service:
-  type: LoadBalancer
-  annotations: 
-    service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path: /healthz
-    external-dns.alpha.kubernetes.io/hostname: monitoring.sqnc-stage.com
-    cert-manager.io/cluster-issuer: letsencrypt-prod
-    cert-manager.io/common-name: monitoring.sqnc-stage.com
-extraArgs:
-  default-ssl-certificate: "monitoring/monitoring-sqnc-stage-com-prod-tls"
-nodeSelector:
-  kubernetes.io/os: linux
-tolerations:
-  - effect: NoSchedule
-    key: node-role.kubernetes.io/master
-    operator: Equal
-  - effect: NoSchedule
-    key: node-role.kubernetes.io/control-plane
-    operator: Equal
-containerPorts:
-  http: 80
-  https: 443
-metrics:
-  enabled: true
-  serviceMonitor:
+controller:
+  watchIngressWithoutClass: true
+  scope:
     enabled: true
-    namespace: monitoring
-    relabelings:
-      - action: replace
-        sourceLabels: [namespace]
-        targetLabel: kubernetes_namespace
-global:
-  security:
-    allowInsecureImages: true
-image:
-  repository: bitnamilegacy/nginx-ingress-controller
-defaultBackend:
-  image:
-    repository: bitnamilegacy/nginx
+  ingressClassResource:
+    name: nginx-monitoring
+    default: false
+  service:
+    type: LoadBalancer
+    annotations:
+      service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path: /healthz
+      external-dns.alpha.kubernetes.io/hostname: monitoring.sqnc-stage.com
+      cert-manager.io/cluster-issuer: letsencrypt-prod
+      cert-manager.io/common-name: monitoring.sqnc-stage.com
+  extraArgs:
+    default-ssl-certificate: "monitoring/monitoring-sqnc-stage-com-prod-tls"
+  nodeSelector:
+    kubernetes.io/os: linux
+  tolerations:
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/master
+      operator: Equal
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/control-plane
+      operator: Equal
+  containerPort:
+    http: 80
+    https: 443
+  metrics:
+    enabled: true
+    serviceMonitor:
+      enabled: true
+      namespace: monitoring
+      relabelings:
+        - action: replace
+          sourceLabels: [namespace]
+          targetLabel: kubernetes_namespace

--- a/clusters/sqnc-staging/monitoring/source.yaml
+++ b/clusters/sqnc-staging/monitoring/source.yaml
@@ -44,3 +44,12 @@ metadata:
 spec:
   interval: 1m
   url: https://jaegertracing.github.io/helm-charts
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: ingress-nginx
+  namespace: monitoring
+spec:
+  interval: 10m
+  url: https://kubernetes.github.io/ingress-nginx


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

- [x] Bug Fix
- [x] Breaking Change (fix or feature that would cause existing functionality to change)

## Linked tickets

SQNC-211

## High level description

As part of the broader move away from Bitnami's charts to avoid its impending suspension of public image releases, this request will essentially just swap out the existing configuration for the Kubernetes community's own [ingress-chart](https://github.com/kubernetes/ingress-nginx/tree/main/charts/ingress-nginx).

## Detailed description

All of the configuration in the existing chart is mirrored within its replacement, with few exceptions:

- All root level fields are indented under `controller` in the ingress-nginx chart
- `containerPorts` instead becomes `containerPort` with ingress-nginx

There are five namespaces in the sqnc-staging environment, each with their own specific ingress resource:

- monitoring
- keycloak
- demanda
- demandb
- match2

Chart replacements will be replicated across all of them, one after another.