### PR TITLE
Use K8s ingress-nginx chart on production

### DIFF
--- a/clusters/l3-sqnc/base/flux-system/gotk-sync.yaml
+++ b/clusters/l3-sqnc/base/flux-system/gotk-sync.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: chore/add_ingress_nginx_chart_to_production
+    branch: main
   url: https://github.com/digicatapult/sqnc-flux-infra.git
 
 ---

--- a/clusters/l3-sqnc/base/flux-system/gotk-sync.yaml
+++ b/clusters/l3-sqnc/base/flux-system/gotk-sync.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: main
+    branch: chore/add_ingress_nginx_chart_to_production
   url: https://github.com/digicatapult/sqnc-flux-infra.git
 
 ---

--- a/clusters/l3-sqnc/capacity/nginx/release.yaml
+++ b/clusters/l3-sqnc/capacity/nginx/release.yaml
@@ -8,17 +8,20 @@ spec:
   install:
     remediation:
       retries: -1
-  releaseName: nginx-ingress-controller
+  upgrade:
+    remediation:
+      retries: -1
+  releaseName: ingress-nginx
   chart:
     spec:
-      version: 11.6.12
-      chart: nginx-ingress-controller
+      chart: ingress-nginx
       sourceRef:
         kind: HelmRepository
-        name: bitnami-oci
+        name: ingress-nginx
+      version: "4.13.2"
   interval: 10m0s
   # Default values
-  # https://github.com/bitnami/charts/blob/master/bitnami/nginx-ingress-controller/values.yaml
+  # https://github.com/kubernetes/ingress-nginx/blob/main/charts/ingress-nginx/values.yaml
   valuesFrom:
     - kind: ConfigMap
       name: capacity-values

--- a/clusters/l3-sqnc/capacity/nginx/values.yaml
+++ b/clusters/l3-sqnc/capacity/nginx/values.yaml
@@ -1,46 +1,38 @@
-watchIngressWithoutClass: true
-scope:
-  enabled: true
-ingressClassResource:
-  name: nginx-capacity
-  default: false
-service:
-  type: LoadBalancer
-  annotations: 
-    service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path: /healthz
-    external-dns.alpha.kubernetes.io/hostname: capacity.dsch-l3.com
-    cert-manager.io/cluster-issuer: letsencrypt-prod
-    cert-manager.io/common-name: capacity.dsch-l3.com
-extraArgs:
-  default-ssl-certificate: "capacity/capacity-dsch-l3-com-prod-tls"
-nodeSelector:
-  kubernetes.io/os: linux
-tolerations:
-  - effect: NoSchedule
-    key: node-role.kubernetes.io/master
-    operator: Equal
-  - effect: NoSchedule
-    key: node-role.kubernetes.io/control-plane
-    operator: Equal
-containerPorts:
-  http: 80
-  https: 443
-metrics:
-  enabled: true
-  serviceMonitor:
+# https://github.com/kubernetes/ingress-nginx/blob/main/charts/ingress-nginx/values.yaml
+controller:
+  watchIngressWithoutClass: true
+  scope:
     enabled: true
-    namespace: capacity
-    relabelings:
-      - action: replace
-        sourceLabels: [namespace]
-        targetLabel: kubernetes_namespace
-global:
-  imagePullSecrets:
-    - name: dockerhub
-  security:
-    allowInsecureImages: true
-image:
-  repository: bitnamilegacy/nginx-ingress-controller
-defaultBackend:
-  image:
-    repository: bitnamilegacy/nginx
+  ingressClassResource:
+    name: nginx-capacity
+    default: false
+  service:
+    type: LoadBalancer
+    annotations:
+      service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path: /healthz
+      external-dns.alpha.kubernetes.io/hostname: capacity.dsch-l3.com
+      cert-manager.io/cluster-issuer: letsencrypt-prod
+      cert-manager.io/common-name: capacity.dsch-l3.com
+  extraArgs:
+    default-ssl-certificate: "capacity/capacity-dsch-l3-com-prod-tls"
+  nodeSelector:
+    kubernetes.io/os: linux
+  tolerations:
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/master
+      operator: Equal
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/control-plane
+      operator: Equal
+  containerPort:
+    http: 80
+    https: 443
+  metrics:
+    enabled: true
+    serviceMonitor:
+      enabled: true
+      namespace: capacity
+      relabelings:
+        - action: replace
+          sourceLabels: [namespace]
+          targetLabel: kubernetes_namespace

--- a/clusters/l3-sqnc/capacity/source.yaml
+++ b/clusters/l3-sqnc/capacity/source.yaml
@@ -26,3 +26,12 @@ spec:
   type: "oci"
   interval: 10m
   url: oci://registry-1.docker.io/bitnamicharts
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: ingress-nginx
+  namespace: capacity
+spec:
+  interval: 10m
+  url: https://kubernetes.github.io/ingress-nginx

--- a/clusters/l3-sqnc/keycloak/nginx/release.yaml
+++ b/clusters/l3-sqnc/keycloak/nginx/release.yaml
@@ -8,17 +8,20 @@ spec:
   install:
     remediation:
       retries: -1
-  releaseName: nginx-ingress-controller
+  upgrade:
+    remediation:
+      retries: -1
+  releaseName: ingress-nginx
   chart:
     spec:
-      version: 11.6.12
-      chart: nginx-ingress-controller
+      chart: ingress-nginx
       sourceRef:
         kind: HelmRepository
-        name: bitnami-oci
+        name: ingress-nginx
+      version: "4.13.2"
   interval: 10m0s
   # Default values
-  # https://github.com/bitnami/charts/blob/master/bitnami/nginx-ingress-controller/values.yaml
+  # https://github.com/kubernetes/ingress-nginx/blob/main/charts/ingress-nginx/values.yaml
   valuesFrom:
     - kind: ConfigMap
       name: keycloak-values

--- a/clusters/l3-sqnc/keycloak/nginx/values.yaml
+++ b/clusters/l3-sqnc/keycloak/nginx/values.yaml
@@ -1,46 +1,38 @@
-global:
-  imagePullSecrets:
-    - name: dockerhub
-  security:
-    allowInsecureImages: true
-image:
-  repository: bitnamilegacy/nginx-ingress-controller
-defaultBackend:
-  image:
-    repository: bitnamilegacy/nginx
-watchIngressWithoutClass: true
-scope:
-  enabled: true
-ingressClassResource:
-  name: nginx-keycloak
-  default: false
-service:
-  type: LoadBalancer
-  annotations: 
-    service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path: /healthz
-    external-dns.alpha.kubernetes.io/hostname: auth.dsch-l3.com
-    cert-manager.io/cluster-issuer: letsencrypt-prod
-    cert-manager.io/common-name: auth.dsch-l3.com
-extraArgs:
-  default-ssl-certificate: "keycloak/auth-dsch-l3-com-prod-tls"
-nodeSelector:
-  kubernetes.io/os: linux
-tolerations:
-  - effect: NoSchedule
-    key: node-role.kubernetes.io/master
-    operator: Equal
-  - effect: NoSchedule
-    key: node-role.kubernetes.io/control-plane
-    operator: Equal
-containerPorts:
-  http: 80
-  https: 443
-metrics:
-  enabled: true
-  serviceMonitor:
+# https://github.com/kubernetes/ingress-nginx/blob/main/charts/ingress-nginx/values.yaml
+controller:
+  watchIngressWithoutClass: true
+  scope:
     enabled: true
-    namespace: keycloak
-    relabelings:
-      - action: replace
-        sourceLabels: [namespace]
-        targetLabel: kubernetes_namespace
+  ingressClassResource:
+    name: nginx-keycloak
+    default: false
+  service:
+    type: LoadBalancer
+    annotations:
+      service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path: /healthz
+      external-dns.alpha.kubernetes.io/hostname: auth.dsch-l3.com
+      cert-manager.io/cluster-issuer: letsencrypt-prod
+      cert-manager.io/common-name: auth.dsch-l3.com
+  extraArgs:
+    default-ssl-certificate: "keycloak/auth-dsch-l3-com-prod-tls"
+  nodeSelector:
+    kubernetes.io/os: linux
+  tolerations:
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/master
+      operator: Equal
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/control-plane
+      operator: Equal
+  containerPort:
+    http: 80
+    https: 443
+  metrics:
+    enabled: true
+    serviceMonitor:
+      enabled: true
+      namespace: keycloak
+      relabelings:
+        - action: replace
+          sourceLabels: [namespace]
+          targetLabel: kubernetes_namespace

--- a/clusters/l3-sqnc/keycloak/source.yaml
+++ b/clusters/l3-sqnc/keycloak/source.yaml
@@ -25,3 +25,12 @@ metadata:
 spec:
   interval: 10m
   url: https://codecentric.github.io/helm-charts
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: ingress-nginx
+  namespace: keycloak
+spec:
+  interval: 10m
+  url: https://kubernetes.github.io/ingress-nginx

--- a/clusters/l3-sqnc/monitoring/nginx/release.yaml
+++ b/clusters/l3-sqnc/monitoring/nginx/release.yaml
@@ -8,17 +8,20 @@ spec:
   install:
     remediation:
       retries: -1
-  releaseName: nginx-ingress-controller
+  upgrade:
+    remediation:
+      retries: -1
+  releaseName: ingress-nginx
   chart:
     spec:
-      version: 11.6.12
-      chart: nginx-ingress-controller
+      chart: ingress-nginx
       sourceRef:
         kind: HelmRepository
-        name: bitnami-oci
+        name: ingress-nginx
+      version: "4.13.2"
   interval: 10m
   # Default values
-  # https://github.com/bitnami/charts/blob/master/bitnami/nginx-ingress-controller/values.yaml
+  # https://github.com/kubernetes/ingress-nginx/blob/main/charts/ingress-nginx/values.yaml
   valuesFrom:
     - kind: ConfigMap
       name: monitoring-values

--- a/clusters/l3-sqnc/monitoring/nginx/values.yaml
+++ b/clusters/l3-sqnc/monitoring/nginx/values.yaml
@@ -1,46 +1,38 @@
-global:
-  imagePullSecrets:
-    - name: dockerhub
-  security:
-    allowInsecureImages: true
-image:
-  repository: bitnamilegacy/nginx-ingress-controller
-defaultBackend:
-  image:
-    repository: bitnamilegacy/nginx
-watchIngressWithoutClass: true
-scope:
-  enabled: true
-ingressClassResource:
-  name: nginx-monitoring
-  default: false
-service:
-  type: LoadBalancer
-  annotations: 
-    service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path: /healthz
-    external-dns.alpha.kubernetes.io/hostname: monitoring.dsch-l3.com
-    cert-manager.io/cluster-issuer: letsencrypt-prod
-    cert-manager.io/common-name: monitoring.dsch-l3.com
-extraArgs:
-  default-ssl-certificate: "monitoring/monitoring-dsch-l3-com-prod-tls"
-nodeSelector:
-  kubernetes.io/os: linux
-tolerations:
-  - effect: NoSchedule
-    key: node-role.kubernetes.io/master
-    operator: Equal
-  - effect: NoSchedule
-    key: node-role.kubernetes.io/control-plane
-    operator: Equal
-containerPorts:
-  http: 80
-  https: 443
-metrics:
-  enabled: true
-  serviceMonitor:
+# https://github.com/kubernetes/ingress-nginx/blob/main/charts/ingress-nginx/values.yaml
+controller:
+  watchIngressWithoutClass: true
+  scope:
     enabled: true
-    namespace: monitoring
-    relabelings:
-      - action: replace
-        sourceLabels: [namespace]
-        targetLabel: kubernetes_namespace
+  ingressClassResource:
+    name: nginx-monitoring
+    default: false
+  service:
+    type: LoadBalancer
+    annotations:
+      service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path: /healthz
+      external-dns.alpha.kubernetes.io/hostname: monitoring.dsch-l3.com
+      cert-manager.io/cluster-issuer: letsencrypt-prod
+      cert-manager.io/common-name: monitoring.dsch-l3.com
+  extraArgs:
+    default-ssl-certificate: "monitoring/monitoring-dsch-l3-com-prod-tls"
+  nodeSelector:
+    kubernetes.io/os: linux
+  tolerations:
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/master
+      operator: Equal
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/control-plane
+      operator: Equal
+  containerPort:
+    http: 80
+    https: 443
+  metrics:
+    enabled: true
+    serviceMonitor:
+      enabled: true
+      namespace: monitoring
+      relabelings:
+        - action: replace
+          sourceLabels: [namespace]
+          targetLabel: kubernetes_namespace

--- a/clusters/l3-sqnc/monitoring/source.yaml
+++ b/clusters/l3-sqnc/monitoring/source.yaml
@@ -44,3 +44,12 @@ metadata:
 spec:
   interval: 1m
   url: https://jaegertracing.github.io/helm-charts
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: ingress-nginx
+  namespace: monitoring
+spec:
+  interval: 10m
+  url: https://kubernetes.github.io/ingress-nginx

--- a/clusters/l3-sqnc/optimiser/nginx/release.yaml
+++ b/clusters/l3-sqnc/optimiser/nginx/release.yaml
@@ -8,17 +8,20 @@ spec:
   install:
     remediation:
       retries: -1
-  releaseName: nginx-ingress-controller
+  upgrade:
+    remediation:
+      retries: -1
+  releaseName: ingress-nginx
   chart:
     spec:
-      version: 11.6.12
-      chart: nginx-ingress-controller
+      chart: ingress-nginx
       sourceRef:
         kind: HelmRepository
-        name: bitnami-oci
+        name: ingress-nginx
+      version: "4.13.2"
   interval: 10m0s
   # Default values
-  # https://github.com/bitnami/charts/blob/master/bitnami/nginx-ingress-controller/values.yaml
+  # https://github.com/kubernetes/ingress-nginx/blob/main/charts/ingress-nginx/values.yaml
   valuesFrom:
     - kind: ConfigMap
       name: optimiser-values

--- a/clusters/l3-sqnc/optimiser/nginx/values.yaml
+++ b/clusters/l3-sqnc/optimiser/nginx/values.yaml
@@ -1,46 +1,38 @@
-watchIngressWithoutClass: true
-scope:
-  enabled: true
-ingressClassResource:
-  name: nginx-optimiser
-  default: false
-service:
-  type: LoadBalancer
-  annotations: 
-    service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path: /healthz
-    external-dns.alpha.kubernetes.io/hostname: optimiser.dsch-l3.com
-    cert-manager.io/cluster-issuer: letsencrypt-prod
-    cert-manager.io/common-name: optimiser.dsch-l3.com
-extraArgs:
-  default-ssl-certificate: "optimiser/optimiser-dsch-l3-com-prod-tls"
-nodeSelector:
-  kubernetes.io/os: linux
-tolerations:
-  - effect: NoSchedule
-    key: node-role.kubernetes.io/master
-    operator: Equal
-  - effect: NoSchedule
-    key: node-role.kubernetes.io/control-plane
-    operator: Equal
-containerPorts:
-  http: 80
-  https: 443
-metrics:
-  enabled: true
-  serviceMonitor:
+# https://github.com/kubernetes/ingress-nginx/blob/main/charts/ingress-nginx/values.yaml
+controller:
+  watchIngressWithoutClass: true
+  scope:
     enabled: true
-    namespace: optimiser
-    relabelings:
-      - action: replace
-        sourceLabels: [namespace]
-        targetLabel: kubernetes_namespace
-global:
-  imagePullSecrets:
-    - name: dockerhub
-  security:
-    allowInsecureImages: true
-image:
-  repository: bitnamilegacy/nginx-ingress-controller
-defaultBackend:
-  image:
-    repository: bitnamilegacy/nginx
+  ingressClassResource:
+    name: nginx-optimiser
+    default: false
+  service:
+    type: LoadBalancer
+    annotations:
+      service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path: /healthz
+      external-dns.alpha.kubernetes.io/hostname: optimiser.dsch-l3.com
+      cert-manager.io/cluster-issuer: letsencrypt-prod
+      cert-manager.io/common-name: optimiser.dsch-l3.com
+  extraArgs:
+    default-ssl-certificate: "optimiser/optimiser-dsch-l3-com-prod-tls"
+  nodeSelector:
+    kubernetes.io/os: linux
+  tolerations:
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/master
+      operator: Equal
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/control-plane
+      operator: Equal
+  containerPort:
+    http: 80
+    https: 443
+  metrics:
+    enabled: true
+    serviceMonitor:
+      enabled: true
+      namespace: optimiser
+      relabelings:
+        - action: replace
+          sourceLabels: [namespace]
+          targetLabel: kubernetes_namespace

--- a/clusters/l3-sqnc/optimiser/source.yaml
+++ b/clusters/l3-sqnc/optimiser/source.yaml
@@ -26,3 +26,12 @@ spec:
   type: "oci"
   interval: 10m
   url: oci://registry-1.docker.io/bitnamicharts
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: ingress-nginx
+  namespace: optimiser
+spec:
+  interval: 10m
+  url: https://kubernetes.github.io/ingress-nginx

--- a/clusters/l3-sqnc/order/nginx/release.yaml
+++ b/clusters/l3-sqnc/order/nginx/release.yaml
@@ -8,17 +8,20 @@ spec:
   install:
     remediation:
       retries: -1
-  releaseName: nginx-ingress-controller
+  upgrade:
+    remediation:
+      retries: -1
+  releaseName: ingress-nginx
   chart:
     spec:
-      version: 11.6.12
-      chart: nginx-ingress-controller
+      chart: ingress-nginx
       sourceRef:
         kind: HelmRepository
-        name: bitnami-oci
+        name: ingress-nginx
+      version: "4.13.2"
   interval: 10m0s
   # Default values
-  # https://github.com/bitnami/charts/blob/master/bitnami/nginx-ingress-controller/values.yaml
+  # https://github.com/kubernetes/ingress-nginx/blob/main/charts/ingress-nginx/values.yaml
   valuesFrom:
     - kind: ConfigMap
       name: order-values

--- a/clusters/l3-sqnc/order/nginx/values.yaml
+++ b/clusters/l3-sqnc/order/nginx/values.yaml
@@ -1,46 +1,38 @@
-watchIngressWithoutClass: true
-scope:
-  enabled: true
-ingressClassResource:
-  name: nginx-order
-  default: false
-service:
-  type: LoadBalancer
-  annotations: 
-    service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path: /healthz
-    external-dns.alpha.kubernetes.io/hostname: order.dsch-l3.com
-    cert-manager.io/cluster-issuer: letsencrypt-prod
-    cert-manager.io/common-name: order.dsch-l3.com
-extraArgs:
-  default-ssl-certificate: "order/order-dsch-l3-com-prod-tls"
-nodeSelector:
-  kubernetes.io/os: linux
-tolerations:
-  - effect: NoSchedule
-    key: node-role.kubernetes.io/master
-    operator: Equal
-  - effect: NoSchedule
-    key: node-role.kubernetes.io/control-plane
-    operator: Equal
-containerPorts:
-  http: 80
-  https: 443
-metrics:
-  enabled: true
-  serviceMonitor:
+# https://github.com/kubernetes/ingress-nginx/blob/main/charts/ingress-nginx/values.yaml
+controller:
+  watchIngressWithoutClass: true
+  scope:
     enabled: true
-    namespace: order
-    relabelings:
-      - action: replace
-        sourceLabels: [namespace]
-        targetLabel: kubernetes_namespace
-global:
-  imagePullSecrets:
-    - name: dockerhub
-  security:
-    allowInsecureImages: true
-image:
-  repository: bitnamilegacy/nginx-ingress-controller
-defaultBackend:
-  image:
-    repository: bitnamilegacy/nginx
+  ingressClassResource:
+    name: nginx-order
+    default: false
+  service:
+    type: LoadBalancer
+    annotations:
+      service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path: /healthz
+      external-dns.alpha.kubernetes.io/hostname: order.dsch-l3.com
+      cert-manager.io/cluster-issuer: letsencrypt-prod
+      cert-manager.io/common-name: order.dsch-l3.com
+  extraArgs:
+    default-ssl-certificate: "order/order-dsch-l3-com-prod-tls"
+  nodeSelector:
+    kubernetes.io/os: linux
+  tolerations:
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/master
+      operator: Equal
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/control-plane
+      operator: Equal
+  containerPort:
+    http: 80
+    https: 443
+  metrics:
+    enabled: true
+    serviceMonitor:
+      enabled: true
+      namespace: order
+      relabelings:
+        - action: replace
+          sourceLabels: [namespace]
+          targetLabel: kubernetes_namespace

--- a/clusters/l3-sqnc/order/source.yaml
+++ b/clusters/l3-sqnc/order/source.yaml
@@ -26,3 +26,12 @@ spec:
   type: "oci"
   interval: 10m
   url: oci://registry-1.docker.io/bitnamicharts
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: ingress-nginx
+  namespace: order
+spec:
+  interval: 10m
+  url: https://kubernetes.github.io/ingress-nginx


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

- [x] Bug Fix
- [x] Breaking Change (fix or feature that would cause existing functionality to change)

## Linked tickets

SQNC-212

## High level description

As part of the broader move away from Bitnami's charts to avoid its impending suspension of public image releases, this request will essentially just swap out the existing configuration for the Kubernetes community's own [ingress-chart](https://github.com/kubernetes/ingress-nginx/tree/main/charts/ingress-nginx).

## Detailed description

All of the configuration in the existing chart is mirrored within its replacement, with few exceptions:

- All root level fields are indented under `controller` in the ingress-nginx chart
- `containerPorts` instead becomes `containerPort` with ingress-nginx

There are five affected namespaces in the l3-sqnc (production) environment, each with their own specific ingress resource:

- monitoring
- keycloak
- capacity
- optimiser
- order

Chart replacements will be replicated across all of them, one after another.