### PR TITLE
Use new Keycloak 26.4.0 variable

### DIFF
--- a/clusters/kind-cluster/keycloak/release.yaml
+++ b/clusters/kind-cluster/keycloak/release.yaml
@@ -17,7 +17,7 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: codecentric
-      version: "7.1.3"
+      version: "7.1.4"
   interval: 10m0s
   # Default values
   # https://github.com/codecentric/helm-charts/blob/master/charts/keycloakx/values.yaml

--- a/clusters/kind-cluster/keycloak/values.yaml
+++ b/clusters/kind-cluster/keycloak/values.yaml
@@ -28,15 +28,14 @@ extraEnv: |
     value: "http://localhost:3080/auth/"
   - name: KC_HOSTNAME_DEBUG
     value: "true"
-  - name: KC_HOSTNAME_STRICT
-    value: "false"
+  - name: KC_HTTP_MANAGEMENT_SCHEME
+    value: "http"
   - name: JAVA_OPTS_APPEND
     value: >-
       -Djgroups.dns.query={{ include "keycloak.fullname" . }}-headless
 args:
   - "start-dev"
   - "--import-realm"
-  - "--ssl-required=false"
   - "--verbose"
 extraVolumes: |
   - name: realm-volume


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## PR Type

- [x] Bug Fix
- [x] Chore

## High level description

A minor Keycloak patch deprecated the `--ssl-required` flag for the service's start-up script and introduced a new HTTP management layer: `http-management-scheme` to handle connections to the admin console where TLS is unavailable. Because of this change, the end-to-end CI workflow for Keycloak updates is failing. Adding the new variable and removing the deprecated one has resolved the issue in [veritable-flux-infra](https://github.com/digicatapult/veritable-flux-infra), hence that fix is also applicable here.