### PR TITLE
Add cert-manager and Keycloak DB replicas

### DIFF
--- a/clusters/sqnc-staging/base/flux-system/gotk-sync.yaml
+++ b/clusters/sqnc-staging/base/flux-system/gotk-sync.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: main
+    branch: chore/add_replicas_to_mitigate_pdb_issue
   url: https://github.com/digicatapult/sqnc-flux-infra.git
 
 ---

--- a/clusters/sqnc-staging/base/flux-system/gotk-sync.yaml
+++ b/clusters/sqnc-staging/base/flux-system/gotk-sync.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: chore/add_replicas_to_mitigate_pdb_issue
+    branch: main
   url: https://github.com/digicatapult/sqnc-flux-infra.git
 
 ---

--- a/clusters/sqnc-staging/cert-manager/values.yaml
+++ b/clusters/sqnc-staging/cert-manager/values.yaml
@@ -17,3 +17,4 @@ strategy:
 podDisruptionBudget:
   enabled: true
   minAvailable: 1
+replicaCount: 2

--- a/clusters/sqnc-staging/keycloak/cluster/database.yaml
+++ b/clusters/sqnc-staging/keycloak/cluster/database.yaml
@@ -4,7 +4,7 @@ kind: Cluster
 metadata:
   name: cluster
 spec:
-  instances: 1
+  instances: 2
   storage:
     size: 5Gi
     storageClass: managed-csi-premium

--- a/clusters/sqnc-staging/keycloak/cluster/values.yaml
+++ b/clusters/sqnc-staging/keycloak/cluster/values.yaml
@@ -4,6 +4,6 @@ mode: standalone
 version:
   postgresql: "17.4"
 cluster:
-  instances: 1
+  instances: 2
 backups:
   enabled: false


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

- [x] Bug Fix
- [x] Chore

## Linked tickets

ENG-224

## High level description

Because of our move from using a single chart provider (Bitnami) to using many, the default logic for the pod disruption budgets (PDBs) is now more varied. To avoid drainage issues within the K8s node pool, I've bumped the instance count for Keycloak's backend and the replica count for the cert-manager deployment. This allows the clusters to auto-update once again.