### PR TITLE
Add cert-manager and Keycloak DB replicas to prod

### DIFF
--- a/clusters/l3-sqnc/base/flux-system/gotk-sync.yaml
+++ b/clusters/l3-sqnc/base/flux-system/gotk-sync.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: chore/add_prod_replicas_to_mitigate_drainage_issues
+    branch: main
   url: https://github.com/digicatapult/sqnc-flux-infra.git
 
 ---

--- a/clusters/l3-sqnc/base/flux-system/gotk-sync.yaml
+++ b/clusters/l3-sqnc/base/flux-system/gotk-sync.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: main
+    branch: chore/add_prod_replicas_to_mitigate_drainage_issues
   url: https://github.com/digicatapult/sqnc-flux-infra.git
 
 ---

--- a/clusters/l3-sqnc/cert-manager/values.yaml
+++ b/clusters/l3-sqnc/cert-manager/values.yaml
@@ -20,3 +20,4 @@ strategy:
 podDisruptionBudget:
   enabled: true
   minAvailable: 1
+replicaCount: 2

--- a/clusters/l3-sqnc/keycloak/cloudnative-pg/cluster.yaml
+++ b/clusters/l3-sqnc/keycloak/cloudnative-pg/cluster.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: keycloak
 spec:
   imageName: ghcr.io/cloudnative-pg/postgresql:17.4
-  instances: 1
+  instances: 2
   storage:
     size: 5Gi
     storageClass: managed-csi-premium


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

- [x] Bug Fix
- [x] Chore

## Linked tickets

ENG-233

## High level description

This affects the l3-prod environment.

Because of our move from using a single chart provider (Bitnami) to using many, the default logic for the pod disruption budgets (PDBs) is now more varied. To avoid drainage issues within the K8s node pool, I've bumped the instance count for Keycloak's backend and the replica count for the cert-manager deployment. This allows clusters to automatically upgrade Kubernetes once again.