### PR TITLE
Add expected role values to Kind

### DIFF
--- a/clusters/kind-cluster/alice/sqnc-matchmaker-api/values.yaml
+++ b/clusters/kind-cluster/alice/sqnc-matchmaker-api/values.yaml
@@ -68,3 +68,5 @@ postgresql:
           targetLabel: kubernetes_namespace
 podAnnotations:
   instrumentation.opentelemetry.io/inject-nodejs: "monitoring/nodejs-instrumentation"
+roles:
+  - optimiser

--- a/clusters/kind-cluster/base/flux-system/gotk-sync.yaml
+++ b/clusters/kind-cluster/base/flux-system/gotk-sync.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: main
+    branch: test/verify_expected_role_values
   url: https://github.com/digicatapult/sqnc-flux-infra.git
 
 ---

--- a/clusters/kind-cluster/base/flux-system/gotk-sync.yaml
+++ b/clusters/kind-cluster/base/flux-system/gotk-sync.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: test/verify_expected_role_values
+    branch: main
   url: https://github.com/digicatapult/sqnc-flux-infra.git
 
 ---

--- a/clusters/kind-cluster/bob/sqnc-matchmaker-api/values.yaml
+++ b/clusters/kind-cluster/bob/sqnc-matchmaker-api/values.yaml
@@ -69,4 +69,4 @@ postgresql:
 podAnnotations:
   instrumentation.opentelemetry.io/inject-nodejs: "monitoring/nodejs-instrumentation"
 roles:
-  - optimiser
+  - member-a

--- a/clusters/kind-cluster/bob/sqnc-matchmaker-api/values.yaml
+++ b/clusters/kind-cluster/bob/sqnc-matchmaker-api/values.yaml
@@ -68,3 +68,5 @@ postgresql:
           targetLabel: kubernetes_namespace
 podAnnotations:
   instrumentation.opentelemetry.io/inject-nodejs: "monitoring/nodejs-instrumentation"
+roles:
+  - optimiser

--- a/clusters/kind-cluster/charlie/sqnc-matchmaker-api/values.yaml
+++ b/clusters/kind-cluster/charlie/sqnc-matchmaker-api/values.yaml
@@ -69,4 +69,4 @@ postgresql:
 podAnnotations:
   instrumentation.opentelemetry.io/inject-nodejs: "monitoring/nodejs-instrumentation"
 roles:
-  - optimiser
+  - member-b

--- a/clusters/kind-cluster/charlie/sqnc-matchmaker-api/values.yaml
+++ b/clusters/kind-cluster/charlie/sqnc-matchmaker-api/values.yaml
@@ -68,3 +68,5 @@ postgresql:
           targetLabel: kubernetes_namespace
 podAnnotations:
   instrumentation.opentelemetry.io/inject-nodejs: "monitoring/nodejs-instrumentation"
+roles:
+  - optimiser


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## PR Type

- [x] Bug Fix

## Linked tickets

Recent workflow runs for Kind have started [failing](https://github.com/digicatapult/sqnc-flux-infra/actions/runs/20956044797/job/60220803883) due to the handling of `roles` by the matchmaker API. Non-empty values are expected and the chart doesn't provide defaults, hence the fix is to add `optimiser`, `member-a`, and `member-b` to the respective instances.