### PR TITLE
Remove deprecated FluxCD API versions

### DIFF
--- a/clusters/kind-cluster/alice/ipfs-node/release.yaml
+++ b/clusters/kind-cluster/alice/ipfs-node/release.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: alice-ipfs

--- a/clusters/kind-cluster/alice/open-api-merger/release.yaml
+++ b/clusters/kind-cluster/alice/open-api-merger/release.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: alice-open-api

--- a/clusters/kind-cluster/alice/source.yaml
+++ b/clusters/kind-cluster/alice/source.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: digicatapult

--- a/clusters/kind-cluster/alice/sqnc-attachment-api/release.yaml
+++ b/clusters/kind-cluster/alice/sqnc-attachment-api/release.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: alice-sqnc-attachment-api

--- a/clusters/kind-cluster/alice/sqnc-identity-service/release.yaml
+++ b/clusters/kind-cluster/alice/sqnc-identity-service/release.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: alice-identity-service

--- a/clusters/kind-cluster/alice/sqnc-matchmaker-api/release.yaml
+++ b/clusters/kind-cluster/alice/sqnc-matchmaker-api/release.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: alice-sqnc-matchmaker-api

--- a/clusters/kind-cluster/alice/sqnc-node/release.yaml
+++ b/clusters/kind-cluster/alice/sqnc-node/release.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: alice-node

--- a/clusters/kind-cluster/base/app-sync.yaml
+++ b/clusters/kind-cluster/base/app-sync.yaml
@@ -85,19 +85,19 @@ spec:
     name: flux-system
     namespace: flux-system
   healthChecks:
-    - apiVersion: helm.toolkit.fluxcd.io/v2beta1
+    - apiVersion: helm.toolkit.fluxcd.io/v2
       kind: HelmRelease
       name: otel
       namespace: monitoring
-    - apiVersion: helm.toolkit.fluxcd.io/v2beta1
+    - apiVersion: helm.toolkit.fluxcd.io/v2
       kind: HelmRelease
       name: jaeger
       namespace: monitoring
-    - apiVersion: helm.toolkit.fluxcd.io/v2beta1
+    - apiVersion: helm.toolkit.fluxcd.io/v2
       kind: HelmRelease
       name: promtail
       namespace: monitoring
-    - apiVersion: helm.toolkit.fluxcd.io/v2beta1
+    - apiVersion: helm.toolkit.fluxcd.io/v2
       kind: HelmRelease
       name: kube-prometheus-stack
       namespace: monitoring
@@ -158,7 +158,7 @@ spec:
     name: flux-system
     namespace: flux-system
   healthChecks:
-    - apiVersion: helm.toolkit.fluxcd.io/v2beta1
+    - apiVersion: helm.toolkit.fluxcd.io/v2
       kind: HelmRelease
       name: cert-manager
       namespace: cert-manager

--- a/clusters/kind-cluster/base/flux-system/gotk-sync.yaml
+++ b/clusters/kind-cluster/base/flux-system/gotk-sync.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: main
+    branch: chore/replace_beta_api_versions
   url: https://github.com/digicatapult/sqnc-flux-infra.git
 
 ---

--- a/clusters/kind-cluster/base/flux-system/gotk-sync.yaml
+++ b/clusters/kind-cluster/base/flux-system/gotk-sync.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: chore/replace_beta_api_versions
+    branch: main
   url: https://github.com/digicatapult/sqnc-flux-infra.git
 
 ---

--- a/clusters/kind-cluster/bob/ipfs-node/release.yaml
+++ b/clusters/kind-cluster/bob/ipfs-node/release.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: bob-ipfs

--- a/clusters/kind-cluster/bob/open-api-merger/release.yaml
+++ b/clusters/kind-cluster/bob/open-api-merger/release.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: bob-open-api

--- a/clusters/kind-cluster/bob/source.yaml
+++ b/clusters/kind-cluster/bob/source.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: digicatapult

--- a/clusters/kind-cluster/bob/sqnc-attachment-api/release.yaml
+++ b/clusters/kind-cluster/bob/sqnc-attachment-api/release.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: bob-sqnc-attachment-api

--- a/clusters/kind-cluster/bob/sqnc-identity-service/release.yaml
+++ b/clusters/kind-cluster/bob/sqnc-identity-service/release.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: bob-identity-service

--- a/clusters/kind-cluster/bob/sqnc-matchmaker-api/release.yaml
+++ b/clusters/kind-cluster/bob/sqnc-matchmaker-api/release.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: bob-sqnc-matchmaker-api

--- a/clusters/kind-cluster/bob/sqnc-node/release.yaml
+++ b/clusters/kind-cluster/bob/sqnc-node/release.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: bob-node

--- a/clusters/kind-cluster/cert-manager/release.yaml
+++ b/clusters/kind-cluster/cert-manager/release.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: cert-manager 

--- a/clusters/kind-cluster/cert-manager/source.yaml
+++ b/clusters/kind-cluster/cert-manager/source.yaml
@@ -8,7 +8,7 @@ spec:
   interval: 10m
   url: oci://registry-1.docker.io/bitnamicharts
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: cert-manager

--- a/clusters/kind-cluster/charlie/ipfs-node/release.yaml
+++ b/clusters/kind-cluster/charlie/ipfs-node/release.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: charlie-ipfs

--- a/clusters/kind-cluster/charlie/open-api-merger/release.yaml
+++ b/clusters/kind-cluster/charlie/open-api-merger/release.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: charlie-open-api

--- a/clusters/kind-cluster/charlie/source.yaml
+++ b/clusters/kind-cluster/charlie/source.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: digicatapult

--- a/clusters/kind-cluster/charlie/sqnc-attachment-api/release.yaml
+++ b/clusters/kind-cluster/charlie/sqnc-attachment-api/release.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: charlie-sqnc-attachment-api

--- a/clusters/kind-cluster/charlie/sqnc-identity-service/release.yaml
+++ b/clusters/kind-cluster/charlie/sqnc-identity-service/release.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: charlie-identity-service

--- a/clusters/kind-cluster/charlie/sqnc-matchmaker-api/release.yaml
+++ b/clusters/kind-cluster/charlie/sqnc-matchmaker-api/release.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: charlie-sqnc-matchmaker-api

--- a/clusters/kind-cluster/charlie/sqnc-node/release.yaml
+++ b/clusters/kind-cluster/charlie/sqnc-node/release.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: charlie-node

--- a/clusters/kind-cluster/keycloak/cloudnative-pg/release.yaml
+++ b/clusters/kind-cluster/keycloak/cloudnative-pg/release.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: cloudnative-pg

--- a/clusters/kind-cluster/keycloak/cluster/release.yaml
+++ b/clusters/kind-cluster/keycloak/cluster/release.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: cluster

--- a/clusters/kind-cluster/keycloak/release.yaml
+++ b/clusters/kind-cluster/keycloak/release.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: keycloak

--- a/clusters/kind-cluster/keycloak/source.yaml
+++ b/clusters/kind-cluster/keycloak/source.yaml
@@ -9,7 +9,7 @@ spec:
   interval: 1m
   url: oci://registry-1.docker.io/bitnamicharts
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: cloudnative-pg
@@ -18,7 +18,7 @@ spec:
   interval: 10m
   url: https://cloudnative-pg.github.io/charts
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: codecentric

--- a/clusters/kind-cluster/monitoring/jaeger/release.yaml
+++ b/clusters/kind-cluster/monitoring/jaeger/release.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: jaeger

--- a/clusters/kind-cluster/monitoring/kube-prometheus-stack/release.yaml
+++ b/clusters/kind-cluster/monitoring/kube-prometheus-stack/release.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta2
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: kube-prometheus-stack

--- a/clusters/kind-cluster/monitoring/loki/release.yaml
+++ b/clusters/kind-cluster/monitoring/loki/release.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: loki

--- a/clusters/kind-cluster/monitoring/otel/release.yaml
+++ b/clusters/kind-cluster/monitoring/otel/release.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: otel

--- a/clusters/kind-cluster/monitoring/promtail/release.yaml
+++ b/clusters/kind-cluster/monitoring/promtail/release.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: promtail

--- a/clusters/kind-cluster/monitoring/source.yaml
+++ b/clusters/kind-cluster/monitoring/source.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: prometheus-community

--- a/clusters/kind-cluster/nginx/source.yaml
+++ b/clusters/kind-cluster/nginx/source.yaml
@@ -8,7 +8,7 @@ spec:
   interval: 10m
   url: oci://registry-1.docker.io/bitnamicharts
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: ingress-nginx


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

- [x] Chore

## Linked tickets

ENG-273

## High level description

Each of the failing workflows is still only installing FluxCD v2.7.5 via the GitHub Action (`fluxcd/flux2/action@main`), but the beta APIs now can't be called without errors. This deprecation was needed anyway as part of the migration step, to move over to FluxCD v2.8.0.

```
cert-manager	cert-manager-sync 	                  	False    	False	HelmRelease/cert-manager/cert-manager dry-run failed: no matches for kind "HelmRelease" in version "helm.toolkit.fluxcd.io/v2beta1"
```

Switching out the beta versions works.