### PR TITLE
Remove job for a deleted env/directory

### DIFF
--- a/.github/workflows/upgrade-flux.yaml
+++ b/.github/workflows/upgrade-flux.yaml
@@ -34,28 +34,3 @@ jobs:
             title: Update to ${{ steps.update.outputs.flux_version }} kind-cluster
             body: |
               ${{ steps.update.outputs.flux_version }}
-
-  components-l3-sqnc-cluster:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v6
-      - name: Setup Flux CLI
-        uses: fluxcd/flux2/action@main
-      - name: Check for updates
-        id: update
-        run: |
-          flux install \
-            --export > ./clusters/l3-sqnc/base/flux-system/gotk-components.yaml
-
-          VERSION="$(flux -v)"
-          echo "flux_version=$VERSION" >> $GITHUB_OUTPUT
-      - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v8
-        with:
-            token: ${{ secrets.GITHUB_TOKEN }}
-            branch: update-flux-l3-sqnc
-            commit-message: Update to ${{ steps.update.outputs.flux_version }}
-            title: Update to ${{ steps.update.outputs.flux_version }} l3-sqnc
-            body: |
-              ${{ steps.update.outputs.flux_version }}


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

- [x] Chore

## High level description

This removes the job that would upgrade the Flux installation on l3-sqnc, which no longer exists as a directory or environment.