### PR TITLE
Fix Renovate's schedule schema

### DIFF
--- a/renovate.config.js
+++ b/renovate.config.js
@@ -46,8 +46,9 @@ module.exports = (config = {}) => {
         pinDigests: false
       },
       {
+        matchManagers: ["flux"],
         schedule: [
-          "0 9-17 * * *"
+          "*/0 9-17 * * *"
         ]
       },
       {


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

- [x] Bug Fix

## High level description

Renovate throws warning where a schedule is set without a package manager being declared explicitly, and where minutes in the cronjob aren't more accurately defined, e.g. `0` vs `*/0`.